### PR TITLE
Unpack two plugins into folders

### DIFF
--- a/plugin1/top-creators-plugin/assets/css/admin.css
+++ b/plugin1/top-creators-plugin/assets/css/admin.css
@@ -1,0 +1,8 @@
+.copella-creators-admin .cp-creators-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:16px}
+.copella-creators-admin .cp-creator-item{border:1px solid #dcdcde;background:#fff;border-radius:8px;padding:12px}
+.copella-creators-admin .cp-creator-thumb{height:120px;background:#f6f7f7;border-radius:8px;display:flex;align-items:center;justify-content:center;overflow:hidden}
+.copella-creators-admin .cp-creator-thumb img.cp-preview{max-width:100%;height:auto;display:block}
+.copella-creators-admin .cp-placeholder{opacity:.6}
+@media (max-width: 1200px){.copella-creators-admin .cp-creators-grid{grid-template-columns:repeat(2,minmax(0,1fr));}}
+@media (max-width: 680px){.copella-creators-admin .cp-creators-grid{grid-template-columns:1fr;}}
+

--- a/plugin1/top-creators-plugin/assets/css/top-creators.css
+++ b/plugin1/top-creators-plugin/assets/css/top-creators.css
@@ -1,0 +1,37 @@
+/* --- Шрифты --- */
+@font-face { font-family: 'Gilroy-SemiBold'; src: url('https://copella.live/assets/fonts/Gilroy-SemiBold.woff') format('woff'); font-weight: 600; font-style: normal; font-display: swap; }
+@font-face { font-family: 'Gilroy-Bold'; src: url('https://copella.live/assets/fonts/Gilroy-Bold.woff') format('woff'); font-weight: 800; font-style: normal; font-display: swap; }
+
+/* --- Стили блока "Топ авторов" --- */
+.cp-top-creators { --tc-gap: 20px; --tc-radius: 16px; --tc-padding-x: 20px; --tc-padding-x-desktop: 40px; color: #fff; }
+
+/* Заголовок и навигация */
+.cp-top-creators .tc-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 20px; padding: 0 var(--tc-padding-x); }
+.cp-top-creators .tc-title { margin: 0; font-weight: 800; font-size: 20px; font-family: 'Gilroy-Bold', 'Gilroy-SemiBold', system-ui, sans-serif; }
+.cp-top-creators .tc-titlebar { display: none; gap: 8px; }
+@media (min-width: 1024px) { .cp-top-creators .tc-titlebar { display: flex; } }
+.cp-top-creators .tc-nav { appearance: none; background: rgba(255, 255, 255, 0.08); border: 0; color: #fff; border-radius: 50%; width: 32px; height: 32px; display: inline-grid; place-items: center; cursor: pointer; transition: background-color 0.2s ease; }
+.cp-top-creators .tc-nav svg { width: 20px; height: 20px; }
+.cp-top-creators .tc-nav:hover { background-color: rgba(255, 255, 255, 0.15); }
+.cp-top-creators .tc-nav:disabled { opacity: .3; cursor: not-allowed; }
+
+/* Надежная структура карусели */
+.cp-top-creators .tc-viewport { background: transparent; padding: 0; margin: 0; }
+.cp-top-creators .tc-track { display: grid; grid-auto-flow: column; grid-auto-columns: 1fr; gap: var(--tc-gap); padding: 0 var(--tc-padding-x); }
+
+.cp-top-creators .tc-card { position: relative; width: 100%; }
+.cp-top-creators .tc-link { position: absolute; inset: 0; z-index: 3; border-radius: var(--tc-radius); }
+.cp-top-creators .tc-thumb { display: block; width: 100%; aspect-ratio: 1/1; border-radius: var(--tc-radius); background: #0f0f0f; overflow: hidden; position: relative; }
+.cp-top-creators .tc-thumb img { width: 100%; height: 100%; object-fit: cover; display: block; transition: transform .25s ease; }
+.cp-top-creators .tc-card:hover .tc-thumb img { transform: scale(1.05); }
+.cp-top-creators .tc-thumb::after { content: ""; position: absolute; inset: 0; background: linear-gradient(to top, rgba(0,0,0,.6), rgba(0,0,0,0) 60%); z-index: 1; }
+.cp-top-creators .tc-name { position: absolute; left: 12px; right: 12px; bottom: 10px; z-index: 2; font-weight: 600; font-size: clamp(14px, 1.2vw, 16px); text-shadow: 0 1px 2px rgba(0,0,0,.5); font-family: 'Gilroy-SemiBold', system-ui, sans-serif; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+/* Адаптация под мобильные устройства */
+@media (max-width: 1024px) {
+    .cp-top-creators .tc-track { display: flex; overflow-x: auto; scroll-snap-type: x mandatory; padding-bottom: 20px; margin-bottom: -20px; scrollbar-width: none; }
+    .cp-top-creators .tc-track::-webkit-scrollbar { display: none; }
+    .cp-top-creators .tc-card { flex: 0 0 150px; scroll-snap-align: start; }
+}
+@media (max-width: 768px) { .cp-top-creators .tc-card { flex-basis: 140px; } }
+@media (max-width: 560px) { .cp-top-creators .tc-card { flex-basis: 130px; } }

--- a/plugin1/top-creators-plugin/assets/js/top-creators-admin.js
+++ b/plugin1/top-creators-plugin/assets/js/top-creators-admin.js
@@ -1,0 +1,22 @@
+(function($){
+  $(document).on('click', '.cp-select-image', function(){
+    var root = $(this).closest('.cp-creator-item');
+    var field = root.find('.cp-image-id');
+    var frame = wp.media({ title: 'Выберите изображение', multiple: false, library: { type: ['image'] } });
+    frame.on('select', function(){
+      var att = frame.state().get('selection').first().toJSON();
+      field.val(att.id);
+      var img = $('<img/>', { src: (att.sizes && (att.sizes.medium_large || att.sizes.medium || att.sizes.thumbnail)) ? (att.sizes.medium_large ? att.sizes.medium_large.url : (att.sizes.medium ? att.sizes.medium.url : att.sizes.thumbnail.url)) : att.url, class: 'cp-preview' });
+      root.find('.cp-creator-thumb').empty().append(img);
+    });
+    frame.open();
+  });
+
+  $(document).on('click', '.cp-remove-image', function(){
+    var root = $(this).closest('.cp-creator-item');
+    root.find('.cp-image-id').val('0');
+    var idx = $('.cp-creator-item').index(root) + 1;
+    root.find('.cp-creator-thumb').html('<div class="cp-placeholder">Персона '+ idx +'</div>');
+  });
+})(jQuery);
+

--- a/plugin1/top-creators-plugin/top-creators-plugin.php
+++ b/plugin1/top-creators-plugin/top-creators-plugin.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * Plugin Name: Copella Top Creators
+ * Description: Компонент «Лучшие креаторы» в едином стиле сайта.
+ * Version: 1.0.0 (Stable)
+ * Author: Copella
+ * Text Domain: copella-creators
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+define('COPELLA_CREATORS_FILE', __FILE__);
+define('COPELLA_CREATORS_DIR', plugin_dir_path(__FILE__));
+define('COPELLA_CREATORS_URL', plugin_dir_url(__FILE__));
+
+const COPELLA_CREATORS_OPTION = 'copella_top_creators';
+
+function copella_creators_default_options(): array {
+    return [
+        'title' => __('Лучшие креаторы за месяц', 'copella-creators'),
+        'items' => [
+            ['name' => __('Персона 1', 'copella-creators'), 'link' => '', 'image_id' => 0],
+            ['name' => __('Персона 2', 'copella-creators'), 'link' => '', 'image_id' => 0],
+            ['name' => __('Персона 3', 'copella-creators'), 'link' => '', 'image_id' => 0],
+            ['name' => __('Персона 4', 'copella-creators'), 'link' => '', 'image_id' => 0],
+        ]
+    ];
+}
+
+register_activation_hook(__FILE__, function (): void {
+    if (!get_option(COPELLA_CREATORS_OPTION)) {
+        add_option(COPELLA_CREATORS_OPTION, copella_creators_default_options());
+    }
+});
+
+add_action('admin_menu', function (): void {
+    add_menu_page(
+        __('Лучшие креаторы', 'copella-creators'),
+        __('Креаторы', 'copella-creators'),
+        'manage_options',
+        'copella-creators',
+        'copella_creators_render_admin_page',
+        'dashicons-groups',
+        28
+    );
+});
+
+add_action('admin_init', function (): void {
+    register_setting('copella_creators_group', COPELLA_CREATORS_OPTION, 'copella_creators_sanitize_options');
+});
+
+function copella_creators_sanitize_options($raw) {
+    $defaults = copella_creators_default_options();
+    $opts = is_array($raw) ? $raw : array();
+    $clean = array();
+    $clean['title'] = isset($opts['title']) ? sanitize_text_field((string) $opts['title']) : $defaults['title'];
+    $clean['items'] = array();
+    for ($i = 0; $i < 4; $i++) {
+        $item = $opts['items'][$i] ?? array();
+        $clean['items'][$i] = array(
+            'name' => isset($item['name']) ? sanitize_text_field((string) $item['name']) : $defaults['items'][$i]['name'],
+            'link' => isset($item['link']) ? esc_url_raw((string) $item['link']) : '',
+            'image_id' => isset($item['image_id']) ? max(0, (int) $item['image_id']) : 0,
+        );
+    }
+    return $clean;
+}
+
+function copella_creators_admin_enqueue($hook): void {
+    if ($hook !== 'toplevel_page_copella-creators') {
+        return;
+    }
+    wp_enqueue_media();
+    wp_enqueue_style('copella-creators-admin', COPELLA_CREATORS_URL . 'assets/css/admin.css', array(), '1.0.0');
+    wp_enqueue_script('copella-creators-admin', COPELLA_CREATORS_URL . 'assets/js/top-creators-admin.js', array('jquery'), '1.0.0', true);
+}
+add_action('admin_enqueue_scripts', 'copella_creators_admin_enqueue');
+
+function copella_creators_render_admin_page(): void {
+    if (!current_user_can('manage_options')) {
+        return;
+    }
+    $opts = wp_parse_args(get_option(COPELLA_CREATORS_OPTION, array()), copella_creators_default_options());
+    ?>
+    <div class="wrap copella-creators-admin">
+        <h1><?php esc_html_e('Лучшие креаторы', 'copella-creators'); ?></h1>
+        <form method="post" action="options.php">
+            <?php settings_fields('copella_creators_group'); ?>
+            <table class="form-table" role="presentation">
+                <tbody>
+                <tr>
+                    <th scope="row"><label for="cp-title"><?php esc_html_e('Заголовок', 'copella-creators'); ?></label></th>
+                    <td>
+                        <input type="text" id="cp-title" class="regular-text" name="<?php echo esc_attr(COPELLA_CREATORS_OPTION); ?>[title]" value="<?php echo esc_attr($opts['title']); ?>"/>
+                        <p class="description"><?php esc_html_e('Текст заголовка блока', 'copella-creators'); ?></p>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+            <h2 style="margin-top:18px;"><?php esc_html_e('Креаторы', 'copella-creators'); ?></h2>
+            <div class="cp-creators-grid">
+                <?php for ($i = 0; $i < 4; $i++): $item = $opts['items'][$i]; ?>
+                    <div class="cp-creator-item">
+                        <div class="cp-creator-thumb">
+                            <?php if (!empty($item['image_id'])): ?>
+                                <?php echo wp_get_attachment_image((int) $item['image_id'], 'medium', false, array('class' => 'cp-preview')); ?>
+                            <?php else: ?>
+                                <div class="cp-placeholder"><?php echo esc_html(sprintf(__('Персона %d', 'copella-creators'), $i + 1)); ?></div>
+                            <?php endif; ?>
+                        </div>
+                        <p>
+                            <label><?php esc_html_e('Имя', 'copella-creators'); ?><br/>
+                                <input type="text" class="regular-text" name="<?php echo esc_attr(COPELLA_CREATORS_OPTION); ?>[items][<?php echo (int) $i; ?>][name]" value="<?php echo esc_attr($item['name']); ?>"/>
+                            </label>
+                        </p>
+                        <p>
+                            <label><?php esc_html_e('Ссылка (опционально)', 'copella-creators'); ?><br/>
+                                <input type="url" class="regular-text" name="<?php echo esc_attr(COPELLA_CREATORS_OPTION); ?>[items][<?php echo (int) $i; ?>][link]" value="<?php echo esc_attr($item['link']); ?>"/>
+                            </label>
+                        </p>
+                        <input type="hidden" class="cp-image-id" name="<?php echo esc_attr(COPELLA_CREATORS_OPTION); ?>[items][<?php echo (int) $i; ?>][image_id]" value="<?php echo (int) $item['image_id']; ?>"/>
+                        <p>
+                            <button type="button" class="button cp-select-image" data-index="<?php echo (int) $i; ?>"><?php esc_html_e('Выбрать изображение', 'copella-creators'); ?></button>
+                            <button type="button" class="button cp-remove-image" data-index="<?php echo (int) $i; ?>"><?php esc_html_e('Убрать', 'copella-creators'); ?></button>
+                        </p>
+                    </div>
+                <?php endfor; ?>
+            </div>
+            <?php submit_button(); ?>
+        </form>
+        <p style="margin-top:14px">
+            <strong><?php esc_html_e('Шорткод', 'copella-creators'); ?>:</strong>
+            <code>[top_creators]</code>
+        </p>
+    </div>
+    <?php
+}
+
+function copella_creators_register_assets(): void {
+    $css_file = COPELLA_CREATORS_DIR . 'assets/css/top-creators.css';
+    wp_register_style('copella-top-creators', COPELLA_CREATORS_URL . 'assets/css/top-creators.css', array(), file_exists($css_file) ? (string) filemtime($css_file) : '1.0.0');
+}
+add_action('wp_enqueue_scripts', 'copella_creators_register_assets');
+
+// --- ФИНАЛЬНАЯ ФУНКЦИЯ ШОРТКОДА ---
+
+add_shortcode('top_creators', function ($atts = array()): string {
+    $opts = wp_parse_args(get_option(COPELLA_CREATORS_OPTION, array()), copella_creators_default_options());
+
+    $a = shortcode_atts(array(
+        'title' => (string) ($opts['title'] ?? ''),
+        'card_radius' => '16',
+        'gap' => '20',
+    ), $atts, 'top_creators');
+
+    $title = trim((string) $a['title']);
+    $gap = (int) $a['gap'];
+    $radius = (int) $a['card_radius'];
+
+    wp_enqueue_style('copella-top-creators');
+
+    $items = is_array($opts['items'] ?? null) ? $opts['items'] : array();
+    for ($i = 0; $i < 4; $i++) {
+        if (!isset($items[$i])) { $items[$i] = array('name' => sprintf(__('Персона %d', 'copella-creators'), $i + 1), 'link' => '', 'image_id' => 0); }
+    }
+
+    $styleVars = sprintf('--tc-gap:%dpx;--tc-radius:%dpx;', $gap, $radius);
+    $uid = 'top_creators_' . wp_generate_password(8, false, false);
+
+    ob_start();
+    ?>
+    <section id="<?php echo esc_attr($uid); ?>" class="cp-top-creators" style="<?php echo esc_attr($styleVars); ?>">
+        <div class="tc-header">
+            <?php if ($title !== ''): ?>
+                <h3 class="tc-title"><?php echo esc_html($title); ?></h3>
+            <?php endif; ?>
+            <div class="tc-titlebar">
+                <button class="tc-nav tc-prev" type="button" aria-label="<?php esc_attr_e('Назад', 'copella-creators'); ?>">
+                    <svg viewBox="0 0 24 24"><path d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z" fill="currentColor"></path></svg>
+                </button>
+                <button class="tc-nav tc-next" type="button" aria-label="<?php esc_attr_e('Вперед', 'copella-creators'); ?>">
+                    <svg viewBox="0 0 24 24"><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z" fill="currentColor"></path></svg>
+                </button>
+            </div>
+        </div>
+        
+        <div class="tc-viewport">
+            <div class="tc-track" role="list">
+                <?php foreach ($items as $idx => $it):
+                    $name = trim((string) ($it['name'] ?? ''));
+                    if ($name === '') { $name = sprintf(__('Персона %d', 'copella-creators'), $idx + 1); }
+                    $link = esc_url($it['link'] ?? '');
+                    $imageId = (int) ($it['image_id'] ?? 0);
+                    $thumb = $imageId ? wp_get_attachment_image_url($imageId, 'medium_large') : '';
+                    ?>
+                    <div class="tc-card" role="listitem">
+                        <?php if ($link): ?><a class="tc-link" href="<?php echo $link; ?>" title="<?php echo esc_attr($name); ?>"></a><?php endif; ?>
+                        <div class="tc-thumb" aria-hidden="true">
+                            <?php if ($thumb): ?>
+                                <img src="<?php echo esc_url($thumb); ?>" alt="" loading="lazy"/>
+                            <?php else: ?>
+                                <div class="tc-fallback"></div>
+                            <?php endif; ?>
+                        </div>
+                        <div class="tc-name"><?php echo esc_html($name); ?></div>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        </div>
+    </section>
+    <script>
+      (function(){
+        var root=document.getElementById('<?php echo esc_js($uid); ?>');if(!root)return;
+        var track=root.querySelector('.tc-track');var btnPrev=root.querySelector('.tc-prev');var btnNext=root.querySelector('.tc-next');
+        if(!track||!btnPrev||!btnNext)return;
+        function isDesktop(){return window.matchMedia('(min-width:1024px)').matches}
+        function updateButtons(){if(isDesktop()){btnPrev.disabled=!0;btnNext.disabled=!0;return}var max=track.scrollWidth-track.clientWidth-1;btnPrev.disabled=track.scrollLeft<=1;btnNext.disabled=track.scrollLeft>=max}
+        function scrollByDir(dir){var card=track.querySelector('.tc-card');var scrollAmount=card?card.clientWidth*1.5:track.clientWidth*.7;track.scrollBy({left:dir*scrollAmount,behavior:'smooth'})}
+        btnPrev.addEventListener('click',function(){scrollByDir(-1)});btnNext.addEventListener('click',function(){scrollByDir(1)});
+        track.addEventListener('scroll',updateButtons,{passive:!0});window.addEventListener('resize',updateButtons);updateButtons();
+      })();
+    </script>
+    <?php
+    return (string) ob_get_clean();
+});

--- a/plugin2/topics-playlists-plugin/assets/css/topics.css
+++ b/plugin2/topics-playlists-plugin/assets/css/topics.css
@@ -1,0 +1,1934 @@
+@font-face{
+  font-family:'Gilroy-SemiBold';
+  src:url('https://copella.live/assets/fonts/Gilroy-SemiBold.woff') format('woff');
+  font-weight:600;
+  font-style:normal;
+  font-display:swap;
+}
+@font-face{
+  font-family:'Gilroy-Bold';
+  src:url('https://copella.live/assets/fonts/Gilroy-Bold.woff') format('woff');
+  font-weight:700;
+  font-style:normal;
+  font-display:swap;
+}
+
+.copella-ht{
+  color:#fff;
+  background:var(--ht-container-bg, #171717);
+  border-radius:var(--ht-container-radius, 32px);
+  padding:20px 24px 26px 24px;
+  font-family:'Gilroy-SemiBold',system-ui,-apple-system,'Segoe UI',Roboto,Arial,sans-serif;
+}
+.copella-ht .ht-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:18px}
+.copella-ht .ht-titlebar{display:flex;align-items:center;gap:10px}
+.copella-ht .ht-nav{background:transparent;border:0;color:#fff;opacity:.9;width:34px;height:34px;display:grid;place-items:center;border-radius:10px;transition:background .2s ease,opacity .2s ease}
+.copella-ht .ht-nav:hover{background:rgba(255,255,255,.06);opacity:1}
+.copella-ht .ht-nav:disabled{opacity:0.25;pointer-events:none;background:transparent}
+.copella-ht:not(.has-scroll) .ht-nav{display:none}
+.copella-ht .ht-title{margin:0;font-size:22px;font-weight:700;font-family:'Gilroy-Bold','Gilroy-SemiBold',system-ui,-apple-system,'Segoe UI',Roboto,Arial,sans-serif}
+.copella-ht .ht-count{opacity:.9;font-size:14px;background:rgba(255,255,255,.06);padding:6px 10px;border-radius:10px}
+
+.copella-ht .ht-viewport{overflow:hidden}
+.copella-ht .ht-track{display:flex;gap:var(--ht-gap,28px);overflow-x:auto;padding:10px 2px 6px 2px;scroll-snap-type:x mandatory;-webkit-overflow-scrolling:touch}
+/* Flex gap fallback for legacy Edge */
+@supports not (gap: 1rem) {
+  .copella-ht .ht-track{margin-left:-28px}
+  .copella-ht .ht-track > *{margin-left:28px}
+}
+.copella-ht .ht-track::-webkit-scrollbar{display:none;height:0}
+.copella-ht .ht-track{scrollbar-width:none}
+.copella-ht .ht-card{flex:0 0 auto;width:calc((100% - 56px) / 3);/* fallback for browsers without CSS variables */width:calc((100% - (var(--ht-gap,28px) * 2)) / 3);min-width:120px;scroll-snap-align:start;color:inherit;text-decoration:none}
+.copella-ht.is-staggered .ht-card:nth-child(even){margin-top:var(--ht-stagger,56px)}
+.copella-ht .ht-card{color:inherit;text-decoration:none}
+.copella-ht .ht-thumb{display:block;width:100%;aspect-ratio:var(--ht-aspect-ratio,1/1);border-radius:var(--ht-card-radius,28px);overflow:hidden;background:var(--ht-card-placeholder,#FF653A);position:relative}
+
+/* Scheduled topic premiere styles */
+.copella-ht .ht-scheduled {
+  cursor: default;
+  pointer-events: none;
+}
+.copella-ht .ht-scheduled .ht-thumb img {
+  filter: brightness(0.4) saturate(0.6);
+}
+.copella-ht .ht-premiere-banner {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.85);
+  backdrop-filter: blur(2px);
+  border-radius: var(--ht-card-radius, 28px) var(--ht-card-radius, 28px) 0 0;
+  padding: 12px 16px;
+  z-index: 2;
+}
+.copella-ht .ht-premiere-timer {
+  text-align: center;
+  color: #ffffff;
+  font-family: 'Gilroy-SemiBold', system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif;
+}
+.copella-ht .ht-premiere-label {
+  display: block;
+  font-size: 11px;
+  font-weight: 600;
+  opacity: 0.9;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  margin-bottom: 4px;
+  line-height: 1;
+}
+.copella-ht .ht-premiere-time {
+  display: block;
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 1;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.6);
+  letter-spacing: 0.3px;
+}
+@supports not (aspect-ratio: 1 / 1) {
+  .copella-ht .ht-thumb{padding-top:100%}
+  .copella-ht .ht-thumb img{position:absolute;top:0;right:0;bottom:0;left:0}
+}
+.copella-ht .ht-thumb img{width:100%;height:100%;object-fit:cover;display:block}
+.copella-ht .ht-card-title{display:block;margin-top:10px;font-size:14px;color:rgba(255,255,255,.92)}
+
+.copella-ht .ht-pagination{display:flex;gap:10px;justify-content:center;margin-top:18px}
+.copella-ht .ht-pagination a{color:#fff;text-decoration:none;padding:6px 10px;border-radius:10px;background:rgba(255,255,255,.06)}
+.copella-ht .ht-pagination a.is-active{background:#fff;color:#000}
+
+@media (min-width: 1024px){
+  .copella-ht .ht-card{width:calc((100% - 112px) / 5);/* fallback */width:calc((100% - (var(--ht-gap,28px) * 4)) / 5)}
+}
+
+@media (max-width: 640px){
+  .copella-ht{margin-left:12px;margin-right:12px;border-radius:20px;padding:16px}
+  .copella-ht .ht-card{width:calc((100% - 40px) / 3);/* fallback */width:calc((100% - (var(--ht-gap,20px) * 2)) / 3);min-width:100px}
+  
+  /* Mobile premiere banner adjustments */
+  .copella-ht .ht-premiere-banner {
+    padding: 10px 12px;
+  }
+  .copella-ht .ht-premiere-label {
+    font-size: 10px;
+    margin-bottom: 3px;
+  }
+  .copella-ht .ht-premiere-time {
+    font-size: 20px;
+  }
+}
+@supports not (gap: 1rem) {
+  @media (max-width: 640px){
+    .copella-ht .ht-track{margin-left:-20px}
+    .copella-ht .ht-track > *{margin-left:20px}
+  }
+}
+
+@media (max-width: 1024px) and (min-width: 641px){
+  .copella-ht{margin-left:16px;margin-right:16px;border-radius:24px}
+}
+
+/* Simple Topic Playlists - Clean design */
+.copella-playlist{
+  background: var(--pl-container-bg, #171717);
+  color: #fff;
+  border-radius: var(--pl-container-radius, 28px);
+  padding: 20px 24px;
+  font-family: 'Gilroy-SemiBold', system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif;
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  margin: 0 0 24px;
+}
+
+.copella-playlist * {
+  box-sizing: border-box;
+}
+
+/* Simple header styling */
+.copella-playlist > .pl-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  list-style: none;
+  cursor: pointer;
+  margin: 0;
+  padding: 0 0 16px 0;
+}
+
+.copella-playlist .pl-title {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
+  font-family: 'Gilroy-Bold', 'Gilroy-SemiBold', system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif;
+  color: #fff;
+  line-height: 1.25;
+  letter-spacing: 0.005em;
+}
+
+/* Simple arrow */
+.copella-playlist .pl-arrow {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border-radius: 10px;
+  color: #fff;
+  opacity: .9;
+  transition: background .2s ease, opacity .2s ease;
+  line-height: 0;
+  background: transparent;
+  border: 0;
+}
+
+.copella-playlist .pl-arrow:hover {
+  background: rgba(255,255,255,.06);
+  opacity: 1;
+}
+
+.copella-playlist .pl-arrow svg {
+  display: block;
+  width: 20px;
+  height: 20px;
+  transition: transform .3s ease;
+  transform-origin: 50% 50%;
+}
+
+.copella-playlist.is-collapsed .pl-arrow svg {
+  transform: rotate(180deg);
+}
+
+.copella-playlist:not(.is-collapsed) .pl-arrow svg {
+  transform: rotate(0deg);
+}
+
+/* Simple playlist items */
+.copella-playlist .pl-item {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  color: inherit;
+  text-decoration: none;
+  border-radius: 10px;
+  padding: 10px;
+  transition: background .2s ease;
+}
+
+.copella-playlist .pl-item:hover {
+  background: rgba(255,255,255,.06);
+}
+
+.copella-playlist .pl-item:focus-visible {
+  outline: 2px solid rgba(255,255,255,.4);
+  outline-offset: 2px;
+}
+
+/* Simple thumbnails */
+.copella-playlist .pl-thumb {
+  width: 60px;
+  flex: 0 0 auto;
+  aspect-ratio: var(--pl-aspect, 1/1);
+  border-radius: 8px;
+  background: var(--pl-card-placeholder, #FF653A);
+  overflow: hidden;
+  position: relative;
+}
+
+@supports not (aspect-ratio: 1 / 1) {
+  .copella-playlist .pl-thumb {
+    padding-top: 100%;
+  }
+  .copella-playlist .pl-thumb img {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
+}
+
+.copella-playlist .pl-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+/* Simple item content */
+.copella-playlist .pl-item-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.copella-playlist .pl-item-title {
+  display: block;
+  font-size: 14px;
+  line-height: 1.35;
+  color: rgba(255,255,255,.94);
+  font-family: 'Gilroy-SemiBold', system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+  letter-spacing: 0.005em;
+}
+
+.copella-playlist .pl-item-meta {
+  font-size: 12px;
+  color: rgba(255,255,255,.68);
+  font-weight: 500;
+  line-height: 1.3;
+  letter-spacing: 0.01em;
+}
+
+/* Simple badges */
+.copella-playlist .pl-item-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  line-height: 1;
+  padding: 4px 8px;
+  border-radius: 12px;
+  background: #FF653A;
+  color: #fff;
+  font-weight: 600;
+  align-self: flex-start;
+  min-height: 20px;
+}
+
+/* Simple tabs styling */
+.copella-playlist .pl-tabsbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 16px 0 18px 0;
+}
+
+.copella-playlist .pl-tabs-nav {
+  background: transparent;
+  border: 0;
+  color: #fff;
+  opacity: .9;
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border-radius: 10px;
+  transition: background .2s ease, opacity .2s ease;
+}
+
+.copella-playlist .pl-tabs-nav:hover {
+  background: rgba(255,255,255,.06);
+  opacity: 1;
+}
+
+.copella-playlist .pl-tabs-nav:disabled {
+  opacity: .25;
+  pointer-events: none;
+  background: transparent;
+}
+
+.copella-playlist .pl-tab {
+  background: rgba(255,255,255,.06);
+  color: #fff;
+  border: 0;
+  border-radius: 10px;
+  padding: 6px 10px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 14px;
+  line-height: 1;
+  opacity: .9;
+  transition: background .2s ease, opacity .2s ease;
+  flex: 0 0 auto;
+  font-weight: 600;
+}
+
+.copella-playlist .pl-tab:hover {
+  opacity: 1;
+  background: rgba(255,255,255,.1);
+}
+
+.copella-playlist .pl-tab.is-active {
+  background: #fff;
+  color: #000;
+  opacity: 1;
+}
+
+/* Simple collapse behavior */
+.copella-playlist.is-collapsed .pl-panels {
+  display: none;
+}
+
+.copella-playlist .pl-panels > .pl-list:not(.is-grid) {
+  flex-direction: column;
+  gap: 12px;
+}
+
+.copella-playlist .pl-panels > .pl-list.is-grid {
+  grid-template-columns: repeat(auto-fit, minmax(var(--pl-grid-min, 240px), 1fr));
+  gap: 16px;
+  grid-auto-flow: row dense;
+  align-items: stretch;
+  width: 100%;
+}
+
+.copella-playlist .pl-panels > .pl-list.is-grid .pl-item {
+  height: 100%;
+  background: rgba(255,255,255,.04);
+  border-radius: 10px;
+  padding: 12px;
+}
+
+/* Simple empty state */
+.copella-playlist .pl-empty {
+  padding: 20px 0;
+  color: rgba(255,255,255,.7);
+  font-size: 14px;
+  text-align: center;
+  font-style: italic;
+}
+/* Cover functionality preserved from original */
+.copella-playlist.has-cover{padding:0;overflow:hidden}
+.copella-playlist .pl-cover{position:relative;display:grid;align-items:stretch;min-height:var(--pl-cover-height,320px);border-top-left-radius:var(--pl-container-radius,28px);border-top-right-radius:var(--pl-container-radius,28px);overflow:hidden}
+.copella-playlist .pl-cover-media{position:absolute;inset:0;top:0;right:0;bottom:0;left:0}
+.copella-playlist .pl-cover-media img{width:100%;height:100%;object-fit:cover;display:block}
+.copella-playlist .pl-cover-overlay{position:absolute;inset:0;top:0;right:0;bottom:0;left:0;background:linear-gradient(90deg, rgba(0,0,0,.55) 0%, rgba(0,0,0,.25) 60%, rgba(0,0,0,.0) 100%)}
+.copella-playlist .pl-cover--right .pl-cover-overlay{background:linear-gradient(270deg, rgba(0,0,0,.55) 0%, rgba(0,0,0,.25) 60%, rgba(0,0,0,.0) 100%)}
+.copella-playlist .pl-cover-content{position:relative;z-index:1;display:flex;flex-direction:column;gap:10px;padding:24px;min-height:var(--pl-cover-height,320px)}
+.copella-playlist .pl-cover--right .pl-cover-content{align-items:flex-end;text-align:right}
+.copella-playlist .pl-cover-title{margin:0;font-size:22px;line-height:1.2;font-weight:700;font-family:'Gilroy-Bold','Gilroy-SemiBold',system-ui,-apple-system,'Segoe UI',Roboto,Arial,sans-serif;text-shadow:0 2px 10px rgba(0,0,0,.3)}
+.copella-playlist .pl-cover-desc{margin:0;font-size:14px;line-height:1.45;max-width:600px;color:rgba(255,255,255,.9);text-shadow:0 2px 6px rgba(0,0,0,.25)}
+.copella-playlist .pl-cover[data-empty-cover="1"] .pl-cover-overlay{background:linear-gradient(90deg, rgba(23,23,23,1) 0%, rgba(23,23,23,1) 100%)}
+.copella-playlist .pl-cover--right[data-empty-cover="1"] .pl-cover-overlay{background:linear-gradient(270deg, rgba(23,23,23,1) 0%, rgba(23,23,23,1) 100%)}
+.copella-playlist.has-cover > .pl-header{padding:16px 24px;border-top:1px solid rgba(255,255,255,.08);border-bottom:1px solid rgba(255,255,255,.08)}
+.copella-playlist.has-cover:not(.is-collapsed) .pl-cover{display:none}
+.copella-playlist.has-cover > .pl-panels{padding:16px 24px 20px}
+/* Improved mobile responsive adjustments */
+@media (max-width: 640px) {
+  .copella-playlist {
+    margin-left: 12px;
+    margin-right: 12px;
+    border-radius: 20px;
+    padding: 16px;
+  }
+  
+  .copella-playlist .pl-cover-title {
+    font-size: 18px;
+  }
+  
+  .copella-playlist .pl-cover-desc {
+    font-size: 13px;
+  }
+  
+  .copella-playlist .pl-cover-content {
+    padding: 14px;
+  }
+  
+  .copella-playlist .pl-thumb {
+    width: 48px;
+  }
+  
+  .copella-playlist .pl-item {
+    padding: 8px;
+    gap: 10px;
+  }
+  
+  .copella-playlist .pl-item-title {
+    font-size: 13px;
+  }
+  
+  .copella-playlist .pl-title {
+    font-size: 20px;
+  }
+  
+  .copella-playlist .pl-arrow {
+    width: 32px;
+    height: 32px;
+  }
+  
+  .copella-playlist .pl-tabsbar {
+    gap: 8px;
+    margin: 12px 0 14px 0;
+  }
+  
+  .copella-playlist .pl-tab {
+    padding: 6px 8px;
+    font-size: 12px;
+    min-width: 0;
+    max-width: 100px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  
+  .copella-playlist .pl-tabs-nav {
+    width: 30px;
+    height: 30px;
+    opacity: .8;
+  }
+}
+
+@media (max-width: 1024px) and (min-width: 641px) {
+  .copella-playlist {
+    margin-left: 16px;
+    margin-right: 16px;
+    border-radius: 24px;
+  }
+  
+  .copella-playlist .pl-thumb {
+    width: 52px;
+  }
+  
+  .copella-playlist .pl-item-title {
+    font-size: 14px;
+  }
+}
+
+/* Simple tab and panel management */
+.copella-playlist .pl-tabs-viewport {
+  overflow: hidden;
+  flex: 1;
+  min-width: 0;
+}
+
+.copella-playlist .pl-tabs {
+  display: flex;
+  gap: 10px;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  padding: 2px;
+  scrollbar-width: none;
+}
+
+.copella-playlist .pl-tabs::-webkit-scrollbar {
+  display: none;
+  height: 0;
+}
+
+.copella-playlist .pl-tabsbar:not(.has-scroll) .pl-tabs-nav {
+  opacity: .4;
+}
+
+/* Hide category tabs bar when the playlist is collapsed */
+.copella-playlist.is-collapsed .pl-tabsbar {
+  display: none;
+}
+
+.copella-playlist .pl-panels {
+  position: relative;
+  min-width: 0;
+}
+
+.copella-playlist .pl-panels > .pl-list {
+  display: none !important;
+}
+
+.copella-playlist .pl-panels > .pl-list.is-active:not(.is-grid) {
+  display: flex !important;
+}
+
+/* Show only the active grid panel */
+.copella-playlist .pl-panels > .pl-list.is-grid.is-active {
+  display: grid !important;
+}
+
+.copella-playlist .pl-panels > .pl-list {
+  min-width: 0;
+}
+
+/* Layout alignment and spacing */
+.copella-playlist {
+  align-self: flex-start;
+  break-inside: avoid;
+}
+
+.copella-playlist.is-collapsed {
+  align-self: flex-start;
+}
+
+@supports not (gap: 1rem) {
+  .copella-playlist .pl-panels > .pl-list:not(.is-grid) > * {
+    margin-top: 18px;
+  }
+  .copella-playlist .pl-panels > .pl-list:not(.is-grid) > *:first-child {
+    margin-top: 0;
+  }
+}
+
+/* Improved masonry layout with better responsive behavior */
+.cp-masonry{column-gap:24px}
+@media (min-width:1280px){.cp-masonry{column-count:2}}
+@media (max-width:1279px) and (min-width:769px){.cp-masonry{column-count:1;column-gap:20px}}
+@media (max-width:768px){.cp-masonry{column-count:1;column-gap:16px}}
+@media (max-width:640px){.cp-masonry{column-gap:12px}}
+.cp-masonry > *{display:inline-block;width:100%;break-inside:avoid;-webkit-column-break-inside:avoid;margin:0 0 24px}
+@media (max-width:768px){.cp-masonry > *{margin:0 0 16px}}
+@media (max-width:640px){.cp-masonry > *{margin:0 0 12px}}
+
+.wp-block-columns.cp-masonry{column-gap:24px}
+@media (min-width:1280px){.wp-block-columns.cp-masonry{column-count:2}}
+@media (max-width:1279px){.wp-block-columns.cp-masonry{column-count:1}}
+.wp-block-columns.cp-masonry{display:block}
+.wp-block-columns.cp-masonry .wp-block-column{display:contents}
+.wp-block-columns.cp-masonry .wp-block-column > *{display:inline-block;width:100%;break-inside:avoid;-webkit-column-break-inside:avoid;margin:0 0 24px}
+
+.cp-masonry .wp-block-columns{display:contents}
+.cp-masonry .wp-block-column{display:contents}
+.cp-masonry .wp-block-column > *{display:inline-block;width:100%;break-inside:avoid;-webkit-column-break-inside:avoid;margin:0 0 24px}
+
+.cp-masonry .wp-block-group.is-layout-grid,
+.cp-masonry .wp-block-group.is-layout-flex{display:contents}
+.cp-masonry .wp-block-group.is-layout-grid > *,
+.cp-masonry .wp-block-group.is-layout-flex > *{display:inline-block;width:100%;break-inside:avoid;-webkit-column-break-inside:avoid;margin:0 0 24px}
+
+/* Improved grid layouts with better responsive breakpoints */
+.cp-grid-2{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:24px;align-items:start}
+@media (max-width:768px){.cp-grid-2{grid-template-columns:1fr;gap:16px}}
+@media (max-width:640px){.cp-grid-2{gap:12px}}
+
+.cp-grid-3{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:24px;align-items:start}
+@media (max-width:1279px){.cp-grid-3{grid-template-columns:repeat(2,minmax(0,1fr));gap:20px}}
+@media (max-width:768px){.cp-grid-3{grid-template-columns:1fr;gap:16px}}
+@media (max-width:640px){.cp-grid-3{gap:12px}}
+
+.cp-gr, .cp-gr > .wp-block-group{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:24px;align-items:start}
+@media (max-width:1279px){.cp-gr, .cp-gr > .wp-block-group{grid-template-columns:repeat(2,minmax(0,1fr));gap:20px}}
+@media (max-width:768px){.cp-gr, .cp-gr > .wp-block-group{grid-template-columns:1fr;gap:16px}}
+@media (max-width:640px){.cp-gr, .cp-gr > .wp-block-group{gap:12px}}
+
+.cp-grid-3 .copella-playlist{margin:0}
+.cp-grid-3 .copella-playlist.has-cover > .pl-header{padding:12px 16px}
+.cp-grid-3 .copella-playlist.has-cover > .pl-panels{padding:12px 16px 16px}
+.cp-grid-3 .copella-playlist .pl-title{font-size:18px}
+.cp-grid-3 .copella-playlist .pl-item-title{font-size:15px}
+.cp-grid-3 .copella-playlist .pl-thumb{width:76px}
+.cp-grid-3 .copella-playlist .pl-item{padding:8px 10px}
+.cp-grid-3 .copella-playlist .pl-cover{min-height:160px}
+.cp-gr .copella-playlist{margin:0}
+.cp-gr .copella-playlist.has-cover > .pl-header{padding:12px 16px}
+.cp-gr .copella-playlist.has-cover > .pl-panels{padding:12px 16px 16px}
+.cp-gr .copella-playlist .pl-title{font-size:18px}
+.cp-gr .copella-playlist .pl-item-title{font-size:15px}
+.cp-gr .copella-playlist .pl-thumb{width:76px}
+.cp-gr .copella-playlist .pl-item{padding:8px 10px}
+.cp-gr .copella-playlist .pl-cover{min-height:160px}
+
+/* Global overflow prevention and mobile viewport improvements */
+body {
+  overflow-x: hidden;
+  max-width: 100vw;
+  box-sizing: border-box;
+}
+
+/* Enhanced mobile viewport constraints */
+@media (max-width: 768px) {
+  html {
+    overflow-x: hidden;
+  }
+  
+  body {
+    overflow-x: hidden !important;
+    width: 100% !important;
+    max-width: 100vw !important;
+  }
+  
+  .copella-authors {
+    overflow-x: hidden !important;
+  }
+  
+  .copella-authors.is-tabs {
+    overflow-x: hidden !important;
+  }
+  
+  .copella-authors.is-tabs .au-panels {
+    overflow-x: hidden !important;
+  }
+  
+  .copella-authors.is-tabs .au-panel {
+    overflow-x: hidden !important;
+  }
+}
+
+/* Authors grid with improved responsive design */
+.copella-authors{color:#fff;font-family:'Gilroy-SemiBold',system-ui,-apple-system,'Segoe UI',Roboto,Arial,sans-serif;max-width:100%;overflow:hidden;box-sizing:border-box;width:100%;margin:0;padding:0}
+.copella-authors .au-title{margin:0 0 14px 0;font-size:22px;font-weight:700;font-family:'Gilroy-Bold','Gilroy-SemiBold',system-ui,-apple-system,'Segoe UI',Roboto,Arial,sans-serif;line-height:1.2}
+.copella-authors .au-grid{display:grid;grid-template-columns:repeat(var(--au-cols,3),minmax(0,1fr));gap:var(--au-gap,24px);align-items:start;width:100%;max-width:100%;margin:0;padding:0;box-sizing:border-box}
+.copella-authors .au-card{background:#171717;border:1px solid rgba(255,255,255,.06);border-radius:24px;overflow:hidden;align-self:start;display:flex;flex-direction:column;max-width:100%;box-sizing:border-box;position:relative}
+.copella-authors .au-header{display:flex;align-items:center;justify-content:space-between;margin:0;padding:14px 16px;border-bottom:1px solid rgba(255,255,255,.08);cursor:pointer;background:rgba(255,255,255,.02);flex-shrink:0;min-height:56px;box-sizing:border-box}
+.copella-authors .au-name{margin:0;font-size:18px;font-weight:700;font-family:'Gilroy-Bold','Gilroy-SemiBold',system-ui,-apple-system,'Segoe UI',Roboto,Arial,sans-serif;line-height:1.3;letter-spacing:0.01em;flex:1;min-width:0;text-overflow:ellipsis;overflow:hidden}
+.copella-authors .au-header .au-live{display:inline-block;width:10px;height:10px;border-radius:999px;margin-left:8px;vertical-align:middle;background:rgba(255,255,255,.3)}
+.copella-authors .au-header .au-live.is-on{background:#F658A4;box-shadow:0 0 0 4px rgba(246,88,164,.25)}
+.copella-authors .au-header .au-live.is-off{background:rgba(255,255,255,.35)}
+.copella-authors .au-arrow{width:34px;height:34px;display:grid;place-items:center;border:0;background:transparent;border-radius:10px;color:#fff;opacity:.9;transition:background .2s ease,opacity .2s ease;line-height:0;cursor:pointer}
+.copella-authors .au-arrow svg{display:block;transition:transform .2s ease;transform-origin:50% 50%}
+.copella-authors .au-arrow:hover{background:rgba(255,255,255,.06);opacity:1}
+.copella-authors .au-card.is-collapsed .au-arrow svg{transform:rotate(180deg)}
+.copella-authors .au-card:not(.is-collapsed) .au-arrow svg{transform:rotate(0deg)}
+/* Cover with fixed aspect and overlayed watch button */
+.copella-authors .au-cover{position:relative;aspect-ratio:var(--au-cover-ratio,16/9);background:#2a2a2a;overflow:hidden}
+@supports not (aspect-ratio: 1 / 1){
+  .copella-authors .au-cover{position:relative;padding-top:56.25%}
+  .copella-authors .au-cover img{position:absolute;inset:0}
+}
+.copella-authors .au-cover img{width:100%;height:100%;object-fit:cover;display:block}
+.copella-authors .au-cover::after{content:"";position:absolute;left:0;right:0;bottom:0;height:36%;background:linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,.35) 100%);pointer-events:none}
+.copella-authors .au-cover .au-watch{position:absolute;right:12px;bottom:12px;z-index:2;display:inline-flex;align-items:center;justify-content:center;background:#fff;color:#000;text-decoration:none;border-radius:10px;padding:8px 12px;font-size:14px;font-weight:700;font-family:'Gilroy-Bold','Gilroy-SemiBold',system-ui,-apple-system,'Segoe UI',Roboto,Arial,sans-serif;box-shadow:0 6px 20px rgba(0,0,0,.35)}
+.copella-authors .au-cover .au-watch:hover{opacity:.95}
+.copella-authors .au-body{padding:16px;transition:height 0.35s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.35s cubic-bezier(0.4, 0, 0.2, 1), padding 0.35s cubic-bezier(0.4, 0, 0.2, 1);overflow:hidden;max-width:100%;box-sizing:border-box}
+.copella-authors .au-cover + .au-body{border-top:1px solid rgba(255,255,255,.08);padding:16px}
+.copella-authors .au-card.is-collapsed .au-body{height:0;opacity:0;padding-top:0;padding-bottom:0}
+.copella-authors .au-card:not(.is-collapsed) .au-body{opacity:1;padding:16px;height:auto}
+.copella-authors .au-desc{margin:0 0 12px 0;font-size:14px;color:rgba(255,255,255,.82);line-height:1.45;letter-spacing:0.01em}
+.copella-authors .au-playlists .copella-playlist{margin:14px 0 0 0;width:100%;max-width:100%;overflow:hidden;box-sizing:border-box}
+
+/* Inner playlist tabs inside author cards */
+.copella-authors .au-pl-tabsbar{display:flex;align-items:center;gap:10px;margin:12px 0 10px 0;width:100%;max-width:100%;box-sizing:border-box}
+.copella-authors .au-pl-tabs-nav{background:transparent;border:0;color:#fff;opacity:.9;width:34px;height:34px;display:grid;place-items:center;border-radius:10px;transition:background .2s ease,opacity .2s ease;flex-shrink:0}
+.copella-authors .au-pl-tabs-nav:hover{background:rgba(255,255,255,.06);opacity:1}
+.copella-authors .au-pl-tabs-nav:disabled{opacity:.25;pointer-events:none;background:transparent}
+.copella-authors .au-pl-tabs-viewport{overflow:hidden;flex:1;min-width:0;max-width:100%}
+.copella-authors .au-pl-tabs{display:flex;gap:10px;flex-wrap:nowrap;overflow-x:auto;padding:2px 2px 2px 8px;scrollbar-width:none;width:100%;max-width:100%;box-sizing:border-box}
+/* Show navigation arrows on mobile/small screens where scrolling is more common */
+.copella-authors .au-pl-tabsbar:not(.has-scroll) .au-pl-prev,
+.copella-authors .au-pl-tabsbar:not(.has-scroll) .au-pl-next{opacity:.6}
+/* On larger screens, make arrows more subtle when not needed */
+@media (min-width: 1025px) {
+  .copella-authors .au-pl-tabsbar:not(.has-scroll) .au-pl-prev,
+  .copella-authors .au-pl-tabsbar:not(.has-scroll) .au-pl-next{opacity:.25}
+}
+.copella-authors .au-pl-tabs::-webkit-scrollbar{display:none;height:0}
+
+/* Enhanced playlist tab visibility control */
+.copella-authors .au-pl-wrap {
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+.copella-authors .au-pl-wrap[style*="display: none"] {
+  display: none !important;
+}
+
+.copella-authors .au-pl-wrap--title-only[style*="display: none"] {
+  display: none !important;
+}
+
+.copella-authors .au-pl-wrap--full[style*="display: none"] {
+  display: none !important;
+}
+
+.copella-authors .copella-playlist--title-only[style*="display: none"] {
+  display: none !important;
+}
+
+/* Ensure proper display when showing specific playlists */
+.copella-authors .au-pl-wrap--full[style*="display: block"] {
+  display: block !important;
+}
+
+.copella-authors .au-pl-wrap--title-only[style*="display: grid"] {
+  display: grid !important;
+}
+
+/* Single playlist styling - always visible */
+.copella-authors .au-playlists--single {
+  margin-top: 0;
+}
+
+.copella-authors .au-playlists--single .au-pl-wrap--single {
+  display: block !important;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+.copella-authors .au-playlists--single .copella-playlist {
+  margin: 0;
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+}
+
+.copella-authors .au-playlists--single .copella-playlist .pl-header {
+  display: none;
+}
+
+.copella-authors .au-playlists--single .copella-playlist .pl-panels {
+  display: block !important;
+  height: auto !important;
+  opacity: 1 !important;
+  overflow: visible !important;
+}
+.copella-authors .au-pl-tab{background:rgba(255,255,255,.06);color:#fff;border:0;border-radius:12px;padding:8px 12px;cursor:pointer;font:inherit;font-size:14px;line-height:1;opacity:.92;transition:background .2s ease,opacity .2s ease,color .2s ease;flex:0 0 auto;white-space:nowrap;max-width:200px;overflow:hidden;text-overflow:ellipsis}
+.copella-authors .au-pl-tab:hover{opacity:1;background:rgba(255,255,255,.1)}
+.copella-authors .au-pl-tab.is-active{background:#fff;color:#000;opacity:1;box-shadow:0 1px 0 rgba(255,255,255,.25) inset}
+
+/* Mobile improvements for playlist tabs */
+@media (max-width: 1024px) {
+  .copella-authors .au-pl-tabsbar {
+    gap: 8px;
+    margin: 10px 0 8px 0;
+  }
+  
+  .copella-authors .au-pl-tabs-nav {
+    width: 30px;
+    height: 30px;
+    opacity: .8;
+  }
+  
+  .copella-authors .au-pl-tabs-nav:not(:disabled) {
+    opacity: .9;
+  }
+  
+  .copella-authors .au-pl-tabs {
+    gap: 8px;
+    padding: 2px;
+  }
+  
+  .copella-authors .au-pl-tab {
+    padding: 6px 10px;
+    font-size: 13px;
+    min-width: 0;
+    max-width: 120px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+/* Collapsible behavior - improved for consistent smooth animation */
+.copella-authors .au-card.is-stream .au-header{gap:10px}
+.copella-authors .au-card.is-stream .au-header .au-name{flex:1}
+.copella-authors .au-card.is-stream .au-header .au-arrow{margin-left:auto}
+
+/* Enhanced animation transitions for all au-body elements */
+.copella-authors .au-card .au-body{
+  padding:16px;
+  transition:height 0.35s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.35s cubic-bezier(0.4, 0, 0.2, 1), padding 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+  overflow:hidden;
+  max-width:100%;
+  box-sizing:border-box;
+  transform-origin:top;
+}
+
+.copella-authors .au-card.is-collapsed .au-body{
+  height:0;
+  opacity:0;
+  overflow:hidden;
+  padding-top:0;
+  padding-bottom:0;
+  margin-top:0;
+  margin-bottom:0;
+}
+
+/* Improved responsive grid for authors */
+@media (max-width:1279px){.copella-authors .au-grid{grid-template-columns:repeat(2,minmax(0,1fr));gap:20px}}
+@media (max-width:768px){.copella-authors .au-grid{grid-template-columns:1fr;gap:16px;padding:0;margin:0}}
+@media (max-width:640px){.copella-authors .au-grid{gap:12px;padding:0;margin:0}}
+
+/* Consistent side paddings with other blocks */
+@media (max-width: 640px){
+  .copella-authors{margin-left:12px;margin-right:12px;overflow-x:hidden;padding:0;box-sizing:border-box}
+  .copella-authors .au-grid{margin:0;padding:0;width:100%;box-sizing:border-box}
+  .copella-authors .au-card{border-radius:20px;margin:0;position:relative;left:0;right:0;transform:none}
+  .copella-authors .au-header{padding:12px 14px;min-height:52px}
+  .copella-authors .au-name{font-size:16px;line-height:1.25}
+  .copella-authors .au-body{padding:12px 14px}
+  
+  /* Ensure mobile content doesn't overflow */
+  .copella-authors.is-tabs .au-panel {
+    overflow-x: hidden;
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    position: relative;
+    left: 0;
+    right: 0;
+    transform: none;
+    box-sizing: border-box;
+  }
+  
+  .copella-authors.is-tabs .au-panel .au-card--full-width {
+    overflow-x: hidden;
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    position: relative;
+    left: 0;
+    right: 0;
+    transform: none;
+    box-sizing: border-box;
+  }
+  
+  .copella-authors.is-tabs .au-panel .au-card--full-width .au-body {
+    overflow-x: hidden;
+    width: 100%;
+    margin: 0;
+    box-sizing: border-box;
+  }
+  
+  .copella-authors.is-tabs .au-panel .au-playlists {
+    overflow-x: hidden;
+    width: 100%;
+    margin: 0;
+    box-sizing: border-box;
+  }
+}
+@media (max-width: 1024px) and (min-width: 641px){
+  .copella-authors{margin-left:16px;margin-right:16px;overflow-x:hidden;padding:0;box-sizing:border-box}
+  .copella-authors .au-grid{margin:0;padding:0;box-sizing:border-box}
+  .copella-authors .au-card{border-radius:22px;margin:0;position:relative;transform:none}
+  .copella-authors .au-header{padding:13px 15px;min-height:54px}
+  .copella-authors .au-name{font-size:17px}
+}
+
+/* Improved tabs layout with better responsive behavior */
+.copella-authors.is-tabs .au-tabsbar{display:flex;align-items:center;gap:10px;margin:12px 0 14px 0;padding:0 4px;width:100%;max-width:100%;box-sizing:border-box;overflow:hidden}
+.copella-authors.is-tabs .au-tabs-nav{background:transparent;border:0;color:#fff;opacity:.9;width:34px;height:34px;display:grid;place-items:center;border-radius:10px;transition:background .2s ease,opacity .2s ease;flex-shrink:0}
+.copella-authors.is-tabs .au-tabs-nav:hover{background:rgba(255,255,255,.06);opacity:1}
+.copella-authors.is-tabs .au-tabs-nav:disabled{opacity:.25;pointer-events:none;background:transparent}
+/* Better visibility for navigation arrows */
+.copella-authors.is-tabs .au-tabsbar:not(.has-scroll) .au-tabs-nav{opacity:.4}
+.copella-authors.is-tabs .au-tabs-viewport{overflow:hidden;flex:1;min-width:0;max-width:100%}
+.copella-authors.is-tabs .au-tabs{display:flex;gap:10px;flex-wrap:nowrap;padding:2px 8px;overflow-x:auto;scrollbar-width:none;scroll-behavior:smooth;width:100%;max-width:100%;box-sizing:border-box}
+.copella-authors.is-tabs .au-tabs::-webkit-scrollbar{display:none;height:0}
+.copella-authors.is-tabs .au-tab{background:rgba(255,255,255,.06);color:#fff;border:0;border-radius:12px;padding:8px 12px;cursor:pointer;font:inherit;font-size:14px;line-height:1.1;opacity:.92;transition:background .2s ease,opacity .2s ease, color .2s ease;flex:0 0 auto;white-space:nowrap;min-width:max-content;max-width:200px;text-align:center;letter-spacing:0.01em}
+.copella-authors.is-tabs .au-tab:hover{opacity:1;background:rgba(255,255,255,.1)}
+.copella-authors.is-tabs .au-tab.is-active{background:#fff;color:#000;opacity:1;box-shadow:0 1px 0 rgba(255,255,255,.25) inset}
+.copella-authors.is-tabs .au-panels{position:relative;overflow:hidden}
+.copella-authors.is-tabs .au-panel{display:none;width:100%;box-sizing:border-box}
+.copella-authors.is-tabs .au-panel.is-active{display:block}
+
+/* Improved responsive grid for author tabs */
+.copella-authors.is-tabs .au-grid{grid-template-columns:repeat(3,minmax(0,1fr)) !important;gap:var(--au-gap,24px)}
+@media (max-width:1279px){
+  .copella-authors.is-tabs .au-grid{grid-template-columns:repeat(2,minmax(0,1fr)) !important;gap:20px}
+}
+@media (max-width:1024px){
+  /* Fix full-width cards in "All" panel on tablets - make them vertical */
+  .copella-authors.is-tabs .au-panel[data-au-index="all"] .au-card--full-width {
+    flex-direction: column !important;
+    gap: 0 !important;
+    background: #171717 !important;
+    border: 1px solid rgba(255,255,255,.06) !important;
+    border-radius: 22px !important;
+    padding: 0 !important;
+  }
+  
+  .copella-authors.is-tabs .au-panel[data-au-index="all"] .au-card--full-width .au-header {
+    padding: 14px 18px !important;
+    border-bottom: 1px solid rgba(255,255,255,.08) !important;
+    background: rgba(255,255,255,.02) !important;
+  }
+  
+  .copella-authors.is-tabs .au-panel[data-au-index="all"] .au-card--full-width .au-body {
+    padding: 18px !important;
+  }
+}
+@media (max-width:768px){
+  .copella-authors.is-tabs .au-grid{grid-template-columns:1fr !important;gap:16px;margin:0;padding:0;width:100%;box-sizing:border-box}
+  .copella-authors.is-tabs .au-tabsbar{gap:8px;padding:0 2px;margin:12px 0 14px;box-sizing:border-box}
+  .copella-authors.is-tabs .au-tabs-nav{width:30px;height:30px}
+  .copella-authors.is-tabs .au-tab{padding:6px 10px;font-size:13px;max-width:120px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  
+  /* Stronger mobile rules */
+  .copella-authors.is-tabs .au-panel[data-au-index="all"] .au-card--full-width {
+    border-radius: 20px !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    position: relative !important;
+    left: 0 !important;
+    right: 0 !important;
+    transform: none !important;
+    width: 100% !important;
+    box-sizing: border-box !important;
+  }
+  
+  .copella-authors.is-tabs .au-panel[data-au-index="all"] .au-card--full-width .au-header {
+    padding: 12px 16px !important;
+  }
+  
+  .copella-authors.is-tabs .au-panel[data-au-index="all"] .au-card--full-width .au-body {
+    padding: 16px !important;
+  }
+}
+@media (max-width:640px){
+  .copella-authors.is-tabs .au-grid{gap:12px}
+  .copella-authors.is-tabs .au-tab{max-width:100px;padding:5px 8px;font-size:12px}
+}
+
+
+
+/* Социальные сети авторов */
+.au-social{display:flex;flex-wrap:wrap;gap:8px;margin:12px 0 16px 0}
+.au-social-link{display:inline-flex;align-items:center;gap:6px;padding:6px 10px;background:rgba(255,255,255,.08);color:#fff;text-decoration:none;border-radius:8px;font-size:13px;transition:background .2s ease,opacity .2s ease;opacity:.9}
+.au-social-link:hover{background:rgba(255,255,255,.12);opacity:1;color:#fff}
+.au-social-icon{font-size:14px;line-height:1}
+.au-social-name{font-weight:500}
+.au-social-logo{display:inline-flex;align-items:center;margin-right:6px}
+.au-social-logo img{display:block;width:16px;height:16px;border-radius:3px;opacity:.95}
+
+/* Badges alignment inside author playlists too */
+.copella-authors .copella-playlist .pl-item-badge{display:inline-flex;align-items:center;justify-content:center;min-height:22px}
+
+/* Пустое состояние для авторов */
+.au-empty{padding:10px 0;color:rgba(255,255,255,.7);font-size:14px;text-align:center}
+
+.copella-authors .au-stream-program{margin:8px 0 10px}
+.copella-authors .au-stream-info{margin:8px 0 10px; color:rgba(255,255,255,.85); font-size:14px}
+.copella-authors .au-btn{display:inline-flex;align-items:center;justify-content:center;background:#fff;color:#000;text-decoration:none;border-radius:10px;padding:8px 12px;font-size:14px;font-weight:700;font-family:'Gilroy-Bold','Gilroy-SemiBold',system-ui,-apple-system,'Segoe UI',Roboto,Arial,sans-serif}
+.copella-authors .au-btn:hover{opacity:.95}
+.copella-authors .au-watch-link{display:inline-flex;align-items:center;justify-content:center;background:#fff;color:#000;text-decoration:none;border-radius:10px;padding:8px 16px;font-size:14px;font-weight:700;font-family:'Gilroy-Bold','Gilroy-SemiBold',system-ui,-apple-system,'Segoe UI',Roboto,Arial,sans-serif;margin-top:10px;align-self:flex-start}
+.copella-authors .au-watch-link:hover{opacity:.95;color:#000}
+/* Compact overrides for embedded tvschedule (best-effort) */
+.copella-authors .au-program--compact .tv-schedule{background:rgba(255,255,255,.04);border-radius:12px;padding:10px}
+.copella-authors .au-program--compact .tv-schedule-header{opacity:.85;font-size:12px;margin-bottom:6px}
+.copella-authors .au-program--compact .tv-schedule-upcoming-header{opacity:.85;font-size:12px;margin-top:8px}
+.copella-authors .au-program--compact .tv-schedule-now .tv-schedule-current-program{font-size:14px}
+
+.copella-authors .au-program-mini{background:rgba(255,255,255,.04);border-radius:12px;padding:10px}
+.copella-authors .au-program-mini{border:1px solid rgba(255,255,255,.06)}
+.copella-authors .au-program-mini .ap-now{display:flex;gap:8px;align-items:center;margin:0 0 6px 0}
+.copella-authors .au-program-mini .ap-next{display:block}
+.copella-authors .au-program-mini .ap-label{opacity:.75;font-size:12px}
+.copella-authors .au-program-mini .ap-time{font-size:12px;opacity:.85;background:rgba(255,255,255,.08);padding:2px 6px;border-radius:6px}
+.copella-authors .au-program-mini .ap-title{font-size:14px;margin-left:6px}
+.copella-authors .au-program-mini .ap-list{list-style:none;padding:0;margin:6px 0 0 0;display:grid;gap:4px}
+.copella-authors .au-program-mini .ap-list li{display:flex;gap:8px;align-items:center}
+.copella-authors .au-program-mini .ap-empty{opacity:.7}
+.copella-authors .au-program-mini .ap-offline{opacity:.85}
+.copella-authors .au-program-mini .ap-nodata{display:flex;align-items:center;gap:8px;opacity:.85}
+.copella-authors .au-program-mini .ap-nodata .ap-icon{display:inline-flex;align-items:center;justify-content:center;width:20px;height:20px;background:rgba(255,255,255,.08);border-radius:6px}
+.copella-authors .au-program-mini .ap-nodata .ap-text{font-size:14px}
+
+/* Individual author tab layout - compact and efficient */
+.au-grid--individual-tab {
+  display: block !important;
+  grid-template-columns: unset !important;
+}
+
+.au-card--full-width {
+  display: flex;
+  flex-direction: row;
+  gap: 20px;
+  align-items: flex-start;
+  width: 100% !important;
+  max-width: 100% !important;
+}
+
+/* Ensure playlists in individual tabs take full available width */
+.au-grid--individual-tab .au-card--full-width .au-body {
+  width: 100% !important;
+  flex: 1 !important;
+  min-width: 0 !important;
+}
+
+.au-grid--individual-tab .au-card--full-width .au-playlists {
+  width: 100% !important;
+  max-width: 100% !important;
+}
+
+.au-grid--individual-tab .au-card--full-width .au-playlists .au-pl-wrap {
+  width: 100% !important;
+  max-width: 100% !important;
+}
+
+.au-grid--individual-tab .au-card--full-width .au-playlists .au-pl-wrap--title-only {
+  width: 100% !important;
+  max-width: 100% !important;
+  display: grid !important;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)) !important;
+  gap: 16px !important;
+}
+
+/* Force full width for individual author content */
+.au-grid--individual-tab .au-content-wrapper {
+  flex: 1;
+  min-width: 0;
+  width: 100% !important;
+}
+
+.au-card--full-width {
+  display: flex;
+  flex-direction: row;
+  gap: 20px;
+  align-items: flex-start;
+  width: 100% !important;
+  max-width: 100% !important;
+  background: transparent;
+  border: none;
+  padding: 0;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+/* Compact layout when there's no description to prevent excessive spacing */
+.au-card--full-width:not(:has(.au-desc)) {
+  gap: 12px;
+}
+
+/* Fallback for browsers without :has() support */
+@supports not selector(:has(*)) {
+  .au-card--full-width {
+    gap: 12px;
+  }
+}
+
+/* No cover layout - stack content vertically */
+.au-card--no-cover {
+  flex-direction: column !important;
+  gap: 0 !important;
+  background: #171717;
+  border: 1px solid rgba(255,255,255,.06);
+  border-radius: 20px;
+  padding: 0;
+  display: flex;
+  min-height: 0;
+  align-self: start;
+}
+
+.au-card--no-cover .au-header {
+  padding: 16px 20px 12px;
+  border-bottom: 1px solid rgba(255,255,255,.08);
+  background: rgba(255,255,255,.02);
+  border-radius: 20px 20px 0 0;
+}
+
+.au-card--no-cover .au-body {
+  padding: 16px 20px 20px;
+  background: transparent;
+}
+
+/* Compact author cover on individual tabs */
+.au-grid--individual-tab .au-cover {
+  flex: 0 0 280px;
+  aspect-ratio: 16/9;
+  border-radius: 16px;
+  overflow: hidden;
+  position: relative;
+}
+
+/* Smaller cover when there's no description for better proportions */
+.au-grid--individual-tab:not(:has(.au-desc)) .au-cover {
+  flex: 0 0 220px;
+}
+
+/* Fallback for browsers without :has() support */
+@supports not selector(:has(*)) {
+  .au-grid--individual-tab .au-cover {
+    flex: 0 0 220px;
+  }
+}
+
+@supports not (aspect-ratio: 16/9) {
+  .au-grid--individual-tab .au-cover {
+    width: 280px;
+    height: 157px;
+  }
+}
+
+.au-grid--individual-tab .au-content-wrapper {
+  flex: 1;
+  min-width: 0;
+}
+
+/* When in individual tab context, remove collapse functionality */
+.au-grid--individual-tab .au-card--full-width .au-arrow {
+  display: none;
+}
+
+.au-grid--individual-tab .au-card--full-width .au-body {
+  height: auto !important;
+  overflow: visible !important;
+  opacity: 1 !important;
+  padding: 0;
+}
+
+/* Compact playlist layout */
+.au-playlists--compact {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: 16px;
+}
+
+.au-playlists--compact .au-pl-wrap {
+  width: 100%;
+}
+
+/* Make playlists more compact in individual tabs */
+.au-playlists--compact .copella-playlist {
+  margin-bottom: 0;
+  padding: 16px 20px;
+  border-radius: 16px;
+}
+
+.au-playlists--compact .copella-playlist .pl-title {
+  font-size: 18px;
+}
+
+.au-playlists--compact .copella-playlist .pl-thumb {
+  width: 60px;
+}
+
+.au-playlists--compact .copella-playlist .pl-item {
+  padding: 8px 12px;
+  gap: 10px;
+}
+
+.au-playlists--compact .copella-playlist .pl-item-title {
+  font-size: 14px;
+}
+
+.au-playlists--compact .copella-playlist .pl-item-meta {
+  font-size: 11px;
+}
+
+/* Ensure playlists are always expanded in compact layout */
+.au-playlists--compact .copella-playlist.is-collapsed .pl-panels {
+  height: auto !important;
+  opacity: 1 !important;
+  overflow: visible !important;
+}
+
+.au-playlists--compact .copella-playlist.is-collapsed .pl-tabsbar {
+  display: flex !important;
+}
+
+/* Hide collapse arrows in compact mode */
+.au-playlists--compact .copella-playlist .pl-arrow {
+  display: none;
+}
+
+/* Title-only playlist styling (for "All" view) */
+.copella-playlist--title-only {
+  padding: 16px 20px;
+  margin-bottom: 16px;
+  border: 1px solid #3F3F3F;
+}
+
+.copella-playlist--title-only .pl-header {
+  padding: 0;
+  border-bottom: none;
+  cursor: default;
+}
+
+.copella-playlist--title-only .pl-header--no-expand {
+  justify-content: flex-start;
+}
+
+.copella-playlist--title-only .pl-title {
+  font-size: 18px;
+  margin: 0;
+}
+
+/* No hover effects for title-only headers */
+.copella-playlist--title-only .pl-header:hover {
+  background: transparent;
+}
+
+/* Two-column layout for title-only playlists container */
+.au-playlists--title-only {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+  align-items: start;
+}
+
+/* Mixed playlists container - contains both title-only and full versions */
+.au-playlists--mixed {
+  display: block;
+}
+
+/* Title-only wrapper in mixed container - this is the grid container */
+.au-playlists--mixed .au-pl-wrap--title-only {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+  align-items: start;
+}
+
+/* Individual title items within the grid */
+.au-playlists--mixed .au-pl-wrap--title-only .copella-playlist--title-only {
+  /* Remove any margin since grid handles spacing */
+  margin-bottom: 0;
+  /* Ensure text wraps properly in narrow containers */
+  min-width: 0;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+}
+
+.au-playlists--mixed .au-pl-wrap--title-only .copella-playlist--title-only .pl-title {
+  /* Allow title text to wrap */
+  white-space: normal;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  hyphens: auto;
+  line-height: 1.3;
+}
+
+/* Full playlist wrapper in mixed container */
+.au-playlists--mixed .au-pl-wrap--full {
+  display: block;
+  margin-bottom: 20px;
+}
+
+/* Individual project playlist styling - clean and simple */
+.au-playlists--mixed .au-pl-wrap--full .copella-playlist {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  margin: 0;
+}
+
+.au-playlists--mixed .au-pl-wrap--full .copella-playlist .pl-header {
+  display: none;
+}
+
+.au-playlists--mixed .au-pl-wrap--full .copella-playlist .pl-item {
+  background: transparent;
+  border: none;
+  border-radius: 8px;
+  padding: 12px;
+  margin-bottom: 8px;
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  transition: background .2s ease;
+}
+
+.au-playlists--mixed .au-pl-wrap--full .copella-playlist .pl-item:hover {
+  background: rgba(255,255,255,.04);
+}
+
+.au-playlists--mixed .au-pl-wrap--full .copella-playlist .pl-thumb {
+  width: 80px;
+  height: 80px;
+  aspect-ratio: 1/1;
+  border-radius: 8px;
+  flex-shrink: 0;
+}
+
+.au-playlists--mixed .au-pl-wrap--full .copella-playlist .pl-item-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.au-playlists--mixed .au-pl-wrap--full .copella-playlist .pl-item-title {
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.3;
+  color: #fff;
+  margin: 0;
+}
+
+.au-playlists--mixed .au-pl-wrap--full .copella-playlist .pl-item-meta {
+  font-size: 13px;
+  color: rgba(255,255,255,.7);
+  margin: 0;
+}
+
+.au-playlists--mixed .au-pl-wrap--full .copella-playlist .pl-item-badge {
+  background: #FF653A;
+  color: #fff;
+  font-size: 11px;
+  padding: 3px 8px;
+  border-radius: 12px;
+  font-weight: 600;
+  margin-top: 2px;
+  align-self: flex-start;
+}
+
+/* More columns for wide screens */
+@media (min-width: 1600px) {
+  .au-playlists--title-only {
+    grid-template-columns: repeat(4, 1fr);
+  }
+  
+  .au-playlists--mixed .au-pl-wrap--title-only {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+@media (min-width: 1280px) and (max-width: 1599px) {
+  .au-playlists--title-only {
+    grid-template-columns: repeat(3, 1fr);
+  }
+  
+  .au-playlists--mixed .au-pl-wrap--title-only {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+/* Force narrow layout for playlist grids inside author cards */
+/* This ensures project grids within author cards don't use wide-screen column counts */
+.copella-authors .au-playlists--mixed .au-pl-wrap--title-only {
+  grid-template-columns: repeat(2, 1fr) !important;
+}
+
+/* But in individual author tabs, allow more flexibility */
+.au-grid--individual-tab .au-playlists--mixed .au-pl-wrap--title-only {
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)) !important;
+}
+
+@media (max-width: 1024px) {
+  .copella-authors .au-playlists--mixed .au-pl-wrap--title-only {
+    grid-template-columns: 1fr !important;
+  }
+  
+  .au-grid--individual-tab .au-playlists--mixed .au-pl-wrap--title-only {
+    grid-template-columns: 1fr !important;
+  }
+}
+
+/* Responsive adjustments for title-only playlists */
+@media (max-width: 1024px) {
+  .copella-playlist--title-only {
+    padding: 12px 16px;
+    margin-bottom: 12px;
+  }
+  
+  .copella-playlist--title-only .pl-title {
+    font-size: 16px;
+  }
+  
+  .au-playlists--title-only {
+    gap: 12px;
+  }
+  
+  .au-playlists--mixed .au-pl-wrap--title-only {
+    gap: 12px;
+  }
+  
+  /* Better text handling on medium screens */
+  .au-playlists--mixed .au-pl-wrap--title-only .copella-playlist--title-only .pl-title {
+    word-break: break-word;
+    overflow-wrap: break-word;
+  }
+  
+  .au-playlists--mixed .au-pl-wrap--full .copella-playlist .pl-thumb {
+    width: 70px;
+    height: 70px;
+  }
+  
+  .au-playlists--mixed .au-pl-wrap--full .copella-playlist .pl-item-title {
+    font-size: 15px;
+  }
+}
+
+@media (max-width: 768px) {
+  .au-playlists--title-only {
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+  
+  .au-playlists--mixed .au-pl-wrap--title-only {
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+  
+  /* Ensure proper text wrapping on mobile */
+  .au-playlists--mixed .au-pl-wrap--title-only .copella-playlist--title-only {
+    min-width: 0;
+    max-width: 100%;
+  }
+  
+  .au-playlists--mixed .au-pl-wrap--title-only .copella-playlist--title-only .pl-title {
+    font-size: 16px;
+    word-break: break-word;
+    overflow-wrap: anywhere;
+  }
+  
+  .au-playlists--mixed .au-pl-wrap--full .copella-playlist .pl-thumb {
+    width: 60px;
+    height: 60px;
+  }
+  
+  .au-playlists--mixed .au-pl-wrap--full .copella-playlist .pl-item {
+    padding: 10px;
+    gap: 10px;
+  }
+  
+  .au-playlists--mixed .au-pl-wrap--full .copella-playlist .pl-item-title {
+    font-size: 14px;
+  }
+}
+
+@media (max-width: 640px) {
+  .copella-playlist--title-only {
+    padding: 10px 14px;
+    margin-bottom: 10px;
+    border-radius: 16px;
+  }
+  
+  .copella-playlist--title-only .pl-title {
+    font-size: 15px;
+  }
+  
+  .au-playlists--title-only {
+    gap: 8px;
+  }
+  
+  .au-playlists--mixed .au-pl-wrap--title-only {
+    gap: 8px;
+  }
+  
+  .au-playlists--mixed .au-pl-wrap--full .copella-playlist .pl-item {
+    padding: 8px;
+    gap: 8px;
+  }
+  
+  .au-playlists--mixed .au-pl-wrap--full .copella-playlist .pl-thumb {
+    width: 50px;
+    height: 50px;
+  }
+}
+
+/* Smaller tabs in compact mode */
+.au-playlists--compact .au-pl-tab {
+  padding: 6px 10px;
+  font-size: 13px;
+  border-radius: 8px;
+}
+
+.au-playlists--compact .au-pl-tabs-nav {
+  width: 28px;
+  height: 28px;
+}
+
+.au-playlists--compact .au-pl-tabs-nav svg {
+  width: 16px;
+  height: 16px;
+}
+
+/* Mobile responsive improvements for individual tabs */
+@media (max-width: 1024px) {
+  .au-card--full-width {
+    flex-direction: column !important;
+    gap: 16px;
+    margin: 0 !important;
+    padding: 0 !important;
+    width: 100% !important;
+    position: relative !important;
+    left: 0 !important;
+    right: 0 !important;
+    transform: none !important;
+    box-sizing: border-box !important;
+  }
+  
+  .au-grid--individual-tab {
+    width: 100% !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    position: relative !important;
+    left: 0 !important;
+    right: 0 !important;
+    transform: none !important;
+    box-sizing: border-box !important;
+  }
+  
+  .au-grid--individual-tab .au-cover {
+    flex: none;
+    width: 100%;
+    max-width: 400px;
+    margin: 0 auto;
+  }
+  
+  /* Force mobile layout for individual author panels */
+  .copella-authors.is-tabs .au-panel:not([data-au-index="all"]) {
+    margin: 0 !important;
+    padding: 0 !important;
+    width: 100% !important;
+    position: relative !important;
+    left: 0 !important;
+    right: 0 !important;
+    transform: none !important;
+    box-sizing: border-box !important;
+    overflow-x: hidden !important;
+  }
+  
+  .copella-authors.is-tabs .au-panel:not([data-au-index="all"]) .au-card--full-width {
+    flex-direction: column !important;
+    gap: 12px !important;
+    margin: 0 !important;
+    padding: 16px !important;
+    width: 100% !important;
+    transform: none !important;
+    left: 0 !important;
+    right: 0 !important;
+    position: relative !important;
+    box-sizing: border-box !important;
+    overflow-x: hidden !important;
+  }
+  
+  .copella-authors.is-tabs .au-panel:not([data-au-index="all"]) .au-grid--individual-tab {
+    width: 100% !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    transform: none !important;
+    position: relative !important;
+    left: 0 !important;
+    right: 0 !important;
+    box-sizing: border-box !important;
+    overflow-x: hidden !important;
+  }
+  
+  .copella-authors.is-tabs .au-panel:not([data-au-index="all"]) .au-grid--individual-tab .au-cover {
+    display: none !important;
+  }
+  
+  .au-playlists--compact .copella-playlist .pl-thumb {
+    width: 56px;
+  }
+  
+  .copella-authors .au-header {
+    padding: 10px 12px;
+  }
+  
+  .copella-authors .au-name {
+    font-size: 16px;
+  }
+  
+  .copella-authors .au-card {
+    border-radius: 20px;
+  }
+}
+
+@media (max-width: 640px) {
+  .au-card--full-width {
+    gap: 12px;
+    margin: 0 !important;
+    padding: 12px !important;
+    position: relative !important;
+    transform: none !important;
+    left: 0 !important;
+    right: 0 !important;
+    width: 100% !important;
+    box-sizing: border-box !important;
+    overflow-x: hidden !important;
+  }
+  
+  .au-grid--individual-tab {
+    margin: 0 !important;
+    padding: 0 !important;
+    position: relative !important;
+    transform: none !important;
+    width: 100% !important;
+    left: 0 !important;
+    right: 0 !important;
+    box-sizing: border-box !important;
+    overflow-x: hidden !important;
+  }
+  
+  .au-grid--individual-tab .au-cover {
+    max-width: 100%;
+    border-radius: 12px;
+  }
+  
+  /* Fix mobile individual author panels positioning */
+  .copella-authors.is-tabs .au-panel:not([data-au-index="all"]) {
+    position: relative !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    width: 100% !important;
+    transform: none !important;
+    left: 0 !important;
+    right: 0 !important;
+    box-sizing: border-box !important;
+    overflow-x: hidden !important;
+  }
+  
+  .copella-authors.is-tabs .au-panel:not([data-au-index="all"]) .au-grid--individual-tab {
+    position: relative !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    width: 100% !important;
+    transform: none !important;
+    left: 0 !important;
+    right: 0 !important;
+    box-sizing: border-box !important;
+    overflow-x: hidden !important;
+  }
+  
+  .copella-authors.is-tabs .au-panel:not([data-au-index="all"]) .au-card--full-width {
+    position: relative !important;
+    margin: 0 !important;
+    padding: 12px !important;
+    width: 100% !important;
+    transform: none !important;
+    left: 0 !important;
+    right: 0 !important;
+    border-radius: 16px !important;
+    box-sizing: border-box !important;
+    overflow-x: hidden !important;
+  }
+  
+  .au-playlists--compact {
+    gap: 12px;
+    margin-top: 12px;
+    width: 100% !important;
+    overflow-x: hidden !important;
+  }
+  
+  .au-playlists--compact .copella-playlist {
+    padding: 12px 16px;
+    border-radius: 12px;
+    width: 100% !important;
+    box-sizing: border-box !important;
+    overflow-x: hidden !important;
+  }
+  
+  .copella-authors .au-header {
+    padding: 8px 12px;
+  }
+  
+  .copella-authors .au-name {
+    font-size: 15px;
+  }
+  
+  .copella-authors .au-card {
+    border-radius: 16px;
+  }
+  
+  .copella-authors .au-body {
+    padding: 12px;
+    width: 100% !important;
+    box-sizing: border-box !important;
+    overflow-x: hidden !important;
+  }
+  
+  .copella-authors .au-card:not(.is-collapsed) .au-body {
+    padding: 12px;
+  }
+  
+  .copella-authors .au-cover + .au-body {
+    padding: 12px;
+  }
+  
+  .au-card--no-cover .au-body {
+    padding: 12px 16px 16px;
+  }
+  
+  .au-card--no-cover {
+    border-radius: 16px;
+  }
+}
+
+/* Author card styling with small icon instead of large cover */
+.au-card--no-cover .au-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 20px 12px;
+  border-bottom: 1px solid rgba(255,255,255,.08);
+  background: rgba(255,255,255,.02);
+  border-radius: 20px 20px 0 0;
+}
+
+.au-card--no-cover .au-name {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  flex: 1;
+  min-width: 0;
+}
+
+/* Small square author icon with responsive sizing */
+.au-author-icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--ht-card-placeholder, #FF653A);
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  font-weight: 600;
+  color: #fff;
+}
+
+.au-author-icon img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+/* Responsive adjustments for author icons */
+@media (max-width: 768px) {
+  .au-card--no-cover .au-header {
+    gap: 10px;
+    padding: 12px 16px 10px;
+  }
+  
+  .au-card--no-cover .au-name {
+    gap: 8px;
+    font-size: 16px;
+  }
+  
+  .au-author-icon {
+    width: 28px;
+    height: 28px;
+    font-size: 12px;
+  }
+}
+
+@media (max-width: 640px) {
+  .au-card--no-cover .au-header {
+    gap: 8px;
+    padding: 10px 14px 8px;
+  }
+  
+  .au-card--no-cover .au-name {
+    font-size: 15px;
+  }
+  
+  .au-author-icon {
+    width: 24px;
+    height: 24px;
+    border-radius: 4px;
+    font-size: 11px;
+  }
+}
+
+/* Watch link styling for individual author tabs */
+.au-watch-link {
+  display: inline-block;
+  padding: 8px 16px;
+  background: #FF653A;
+  color: #fff;
+  text-decoration: none;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 14px;
+  transition: background .2s ease;
+}
+
+.au-watch-link:hover {
+  background: #e55a34;
+  color: #fff;
+}
+
+/* Complete mobile fix - force individual author tabs to be properly aligned */
+@media (max-width: 768px) {
+  /* Reset all positioning for individual author panels */
+  .copella-authors.is-tabs .au-panel[data-au-index]:not([data-au-index="all"]) {
+    position: static !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    width: 100% !important;
+    left: 0 !important;
+    right: 0 !important;
+    transform: none !important;
+    box-sizing: border-box !important;
+    overflow-x: hidden !important;
+  }
+  
+  .copella-authors.is-tabs .au-panel[data-au-index]:not([data-au-index="all"]) .au-grid--individual-tab {
+    position: static !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    width: 100% !important;
+    left: 0 !important;
+    right: 0 !important;
+    transform: none !important;
+    box-sizing: border-box !important;
+    display: block !important;
+    overflow-x: hidden !important;
+  }
+  
+  .copella-authors.is-tabs .au-panel[data-au-index]:not([data-au-index="all"]) .au-card--full-width {
+    position: static !important;
+    margin: 0 !important;
+    padding: 16px !important;
+    width: 100% !important;
+    left: 0 !important;
+    right: 0 !important;
+    transform: none !important;
+    box-sizing: border-box !important;
+    flex-direction: column !important;
+    background: #171717 !important;
+    border: 1px solid rgba(255,255,255,.06) !important;
+    border-radius: 16px !important;
+    overflow-x: hidden !important;
+  }
+  
+  .copella-authors.is-tabs .au-panel[data-au-index]:not([data-au-index="all"]) .au-card--full-width .au-header {
+    padding: 0 0 12px 0 !important;
+    background: transparent !important;
+    border-bottom: 1px solid rgba(255,255,255,.08) !important;
+  }
+  
+  .copella-authors.is-tabs .au-panel[data-au-index]:not([data-au-index="all"]) .au-card--full-width .au-body {
+    padding: 12px 0 0 0 !important;
+    width: 100% !important;
+  }
+}
+
+/* Enhanced mobile overflow protection */
+@media (max-width: 768px) {
+  .copella-authors {
+    overflow-x: hidden !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    margin: 0 12px !important;
+    padding: 0 !important;
+    box-sizing: border-box !important;
+  }
+  
+  .copella-authors.is-tabs {
+    overflow-x: hidden !important;
+    width: calc(100% - 24px) !important;
+    max-width: calc(100% - 24px) !important;
+    margin: 0 12px !important;
+    padding: 0 !important;
+    box-sizing: border-box !important;
+  }
+  
+  .copella-authors.is-tabs .au-panels {
+    overflow-x: hidden !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    box-sizing: border-box !important;
+  }
+}
+
+/* Mobile layout improvements for better visual perception */
+@media (max-width: 768px) {
+  .copella-authors .au-title {
+    font-size: 20px;
+    margin-bottom: 12px;
+    padding: 0 2px;
+  }
+  
+  .copella-authors .au-desc {
+    font-size: 14px;
+    line-height: 1.4;
+    margin: 0 0 12px 0;
+    color: rgba(255,255,255,.82);
+  }
+  
+  .copella-authors .au-arrow {
+    width: 32px;
+    height: 32px;
+  }
+  
+  .copella-authors .au-arrow svg {
+    width: 18px;
+    height: 18px;
+  }
+}

--- a/plugin2/topics-playlists-plugin/assets/icons/youtube.svg
+++ b/plugin2/topics-playlists-plugin/assets/icons/youtube.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <rect x="2" y="5" width="20" height="14" rx="4" fill="#FF0000"/>
+  <path d="M10 9l6 3-6 3V9z" fill="#FFFFFF"/>
+</svg>
+
+

--- a/plugin2/topics-playlists-plugin/assets/js/authors.js
+++ b/plugin2/topics-playlists-plugin/assets/js/authors.js
@@ -1,0 +1,503 @@
+/**
+ * Copella Authors JavaScript
+ * Handles tabs navigation, card toggling, and playlist interactions
+ */
+(function() {
+    'use strict';
+
+    // Initialize author container functionality
+    function initAuthorContainer(root) {
+        if (!root) return;
+
+        const isTabLayout = root.classList.contains('is-tabs');
+        
+        if (isTabLayout) {
+            initTabsNavigation(root);
+        }
+        
+        initCardToggling(root);
+        initInnerPlaylistTabs(root);
+    }
+
+    // Initialize tabs navigation for tab layout
+    function initTabsNavigation(root) {
+        const tabs = Array.from(root.querySelectorAll('.au-tab'));
+        const tabsTrack = root.querySelector('.au-tabs');
+        const tabsPrev = root.querySelector('.au-tabsbar .au-prev');
+        const tabsNext = root.querySelector('.au-tabsbar .au-next');
+
+        function activateTab(index) {
+            const next = root.querySelector(`.au-panel[data-au-index="${index}"]`);
+            const current = root.querySelector('.au-panel.is-active');
+            
+            if (!next || next === current) return;
+
+            tabs.forEach(tab => {
+                const isActive = tab.getAttribute('data-au-index') === String(index);
+                tab.classList.toggle('is-active', isActive);
+                tab.setAttribute('aria-selected', isActive ? 'true' : 'false');
+            });
+
+            if (current) current.classList.remove('is-active');
+            next.classList.add('is-active');
+        }
+
+        // Tab click handlers
+        root.addEventListener('click', function(e) {
+            const tab = e.target?.closest('.au-tab');
+            if (!tab || !root.contains(tab)) return;
+            
+            const index = tab.getAttribute('data-au-index');
+            activateTab(index);
+        });
+
+        root.addEventListener('keydown', function(e) {
+            const tab = e.target?.closest('.au-tab');
+            if (!tab || !root.contains(tab)) return;
+            
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                activateTab(tab.getAttribute('data-au-index'));
+            }
+        });
+
+        // Tab scrolling
+        function getTabsScrollAmount() {
+            return Math.max(120, root.clientWidth / 3 + 20);
+        }
+
+        function updateTabsButtons() {
+            if (!tabsTrack || !tabsPrev || !tabsNext) return;
+            
+            // Force a small delay to ensure layout is complete
+            requestAnimationFrame(() => {
+                const scrollWidth = tabsTrack.scrollWidth;
+                const clientWidth = tabsTrack.clientWidth;
+                const scrollLeft = tabsTrack.scrollLeft;
+                
+                // Check if there's scrollable content (with a 3px tolerance)
+                const hasScroll = scrollWidth > clientWidth + 3;
+                const maxScroll = Math.max(0, scrollWidth - clientWidth);
+                
+                tabsPrev.disabled = scrollLeft <= 3;
+                tabsNext.disabled = scrollLeft >= maxScroll - 3;
+                
+                const tabsbar = root.querySelector('.au-tabsbar');
+                if (tabsbar) {
+                    tabsbar.classList.toggle('has-scroll', hasScroll);
+                }
+            });
+        }
+
+        function scrollTabsBy(direction) {
+            if (tabsTrack) {
+                tabsTrack.scrollBy({
+                    left: direction * getTabsScrollAmount(),
+                    behavior: 'smooth'
+                });
+            }
+        }
+
+        if (tabsPrev && tabsNext) {
+            tabsPrev.addEventListener('click', () => scrollTabsBy(-1));
+            tabsNext.addEventListener('click', () => scrollTabsBy(1));
+        }
+
+        if (tabsTrack) {
+            tabsTrack.addEventListener('scroll', updateTabsButtons, { passive: true });
+            
+            // Add mouse wheel support for horizontal scrolling
+            tabsTrack.addEventListener('wheel', function(e) {
+                // Only handle horizontal scrolling when there's overflow
+                const hasHorizontalScroll = tabsTrack.scrollWidth > tabsTrack.clientWidth;
+                if (!hasHorizontalScroll) return;
+                
+                // Prevent vertical page scroll and enable horizontal scroll
+                if (Math.abs(e.deltaX) > 0 || Math.abs(e.deltaY) > 0) {
+                    e.preventDefault();
+                    const delta = e.deltaX || e.deltaY;
+                    tabsTrack.scrollBy({
+                        left: delta,
+                        behavior: 'auto'
+                    });
+                }
+            }, { passive: false });
+        }
+
+        window.addEventListener('resize', updateTabsButtons);
+        window.addEventListener('load', updateTabsButtons);
+        
+        if (document.fonts?.ready) {
+            try {
+                document.fonts.ready.then(() => {
+                    setTimeout(updateTabsButtons, 100);
+                });
+            } catch (e) {
+                // Fallback for older browsers
+                setTimeout(updateTabsButtons, 100);
+            }
+        }
+        
+        // Multiple timing checks to ensure layout is ready
+        setTimeout(updateTabsButtons, 0);
+        setTimeout(updateTabsButtons, 100);
+        setTimeout(updateTabsButtons, 300);
+        updateTabsButtons();
+    }
+
+    // Initialize card toggling functionality
+    function initCardToggling(root) {
+        function toggleCard(card) {
+            if (!card || card.__animating) return;
+
+            const header = card.querySelector('.au-header');
+            const body = card.querySelector('.au-body');
+            
+            if (!header || !body) return;
+
+            const isCollapsed = card.classList.contains('is-collapsed');
+            card.__animating = true;
+            
+            let finished = false;
+
+            function doneClosing() {
+                if (finished) return;
+                finished = true;
+                card.classList.add('is-collapsed');
+                body.style.height = '';
+                body.style.opacity = '';
+                body.style.overflow = 'hidden';
+                header.setAttribute('aria-expanded', 'false');
+                card.__animating = false;
+            }
+
+            function doneOpening() {
+                if (finished) return;
+                finished = true;
+                body.style.height = '';
+                body.style.opacity = '';
+                body.style.overflow = '';
+                header.setAttribute('aria-expanded', 'true');
+                card.__animating = false;
+                
+                // Trigger resize event for layout recalculation
+                try {
+                    setTimeout(() => window.dispatchEvent(new Event('resize')), 0);
+                } catch (e) {
+                    // Fallback for older browsers
+                }
+            }
+
+            // Increased timeout to match new CSS transition duration (350ms + buffer)
+            const fallback = setTimeout(() => {
+                isCollapsed ? doneOpening() : doneClosing();
+            }, 500);
+
+            if (isCollapsed) {
+                // Opening animation
+                card.classList.remove('is-collapsed');
+                body.style.overflow = 'hidden';
+                body.style.height = '0px';
+                body.style.opacity = '0';
+                
+                // Force a reflow before starting animation
+                body.offsetHeight;
+                
+                requestAnimationFrame(() => {
+                    body.style.height = body.scrollHeight + 'px';
+                    body.style.opacity = '1';
+                });
+
+                const handleTransition = (ev) => {
+                    if (ev.propertyName !== 'height') return;
+                    clearTimeout(fallback);
+                    doneOpening();
+                    body.removeEventListener('transitionend', handleTransition);
+                };
+
+                body.addEventListener('transitionend', handleTransition);
+            } else {
+                // Closing animation
+                body.style.overflow = 'hidden';
+                body.style.height = body.scrollHeight + 'px';
+                body.style.opacity = '1';
+                
+                // Force a reflow before starting animation
+                body.offsetHeight;
+                
+                requestAnimationFrame(() => {
+                    body.style.height = '0px';
+                    body.style.opacity = '0';
+                });
+
+                const handleTransition = (ev) => {
+                    if (ev.propertyName !== 'height') return;
+                    clearTimeout(fallback);
+                    doneClosing();
+                    body.removeEventListener('transitionend', handleTransition);
+                };
+
+                body.addEventListener('transitionend', handleTransition);
+            }
+        }
+
+        // Card toggle event handlers
+        root.addEventListener('click', function(e) {
+            const arrow = e.target?.closest('.au-arrow');
+            if (arrow && root.contains(arrow)) {
+                e.preventDefault();
+                e.stopPropagation();
+                toggleCard(arrow.closest('.au-card'));
+                return;
+            }
+
+            const header = e.target?.closest('.au-header');
+            if (!header || !root.contains(header)) return;
+            
+            // Only toggle if there's an arrow (not in individual tab view)
+            if (!header.querySelector('.au-arrow')) return;
+            
+            e.preventDefault();
+            e.stopPropagation();
+            toggleCard(header.closest('.au-card'));
+        });
+
+        root.addEventListener('keydown', function(e) {
+            const header = e.target?.closest('.au-header');
+            if (!header || !root.contains(header)) return;
+            
+            // Only toggle if there's an arrow
+            if (!header.querySelector('.au-arrow')) return;
+            
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                toggleCard(header.closest('.au-card'));
+            }
+        });
+    }
+
+    // Initialize inner playlist tabs for each author card
+    function initInnerPlaylistTabs(root) {
+        const cards = root.querySelectorAll('.au-card');
+        
+        cards.forEach(card => {
+            initPlaylistTabsForCard(card);
+        });
+
+        // Re-initialize when cards are expanded
+        const observer = new MutationObserver(mutations => {
+            mutations.forEach(mutation => {
+                if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+                    const card = mutation.target.closest('.au-card');
+                    if (card && !card.classList.contains('is-collapsed')) {
+                        setTimeout(() => initPlaylistTabsForCard(card), 100);
+                    }
+                }
+            });
+        });
+
+        cards.forEach(card => {
+            observer.observe(card, { attributes: true, attributeFilter: ['class'] });
+        });
+    }
+
+    function initPlaylistTabsForCard(card) {
+        const tabsbar = card.querySelector('.au-pl-tabsbar');
+        
+        // Handle single playlist case (no tabs)
+        const singlePlaylistContainer = card.querySelector('.au-playlists--single');
+        if (singlePlaylistContainer && !tabsbar) {
+            // Single playlist is already visible, no need for tab logic
+            return;
+        }
+        
+        if (!tabsbar) return;
+
+        const scroller = tabsbar.querySelector('.au-pl-tabs');
+        const prev = tabsbar.querySelector('.au-pl-prev');
+        const next = tabsbar.querySelector('.au-pl-next');
+
+        function getScrollAmount() {
+            const base = scroller ? scroller.clientWidth : (tabsbar ? tabsbar.clientWidth : 300);
+            return Math.max(120, base / 2 + 20);
+        }
+
+        function updateButtons() {
+            if (!scroller || !prev || !next) return;
+            
+            // Force a small delay to ensure layout is complete
+            requestAnimationFrame(() => {
+                const scrollWidth = scroller.scrollWidth;
+                const clientWidth = scroller.clientWidth;
+                const scrollLeft = scroller.scrollLeft;
+                
+                // Check if there's scrollable content (with a 3px tolerance)
+                const hasScroll = scrollWidth > clientWidth + 3;
+                const maxScroll = Math.max(0, scrollWidth - clientWidth);
+                
+                prev.disabled = scrollLeft <= 3;
+                next.disabled = scrollLeft >= maxScroll - 3;
+                
+                tabsbar.classList.toggle('has-scroll', hasScroll);
+            });
+        }
+
+        function scrollByDirection(direction) {
+            if (scroller) {
+                scroller.scrollBy({
+                    left: direction * getScrollAmount(),
+                    behavior: 'smooth'
+                });
+            }
+        }
+
+        if (prev && next) {
+            prev.addEventListener('click', () => scrollByDirection(-1));
+            next.addEventListener('click', () => scrollByDirection(1));
+        }
+
+        if (scroller) {
+            scroller.addEventListener('scroll', updateButtons, { passive: true });
+            
+            // Add mouse wheel support for horizontal scrolling
+            scroller.addEventListener('wheel', function(e) {
+                // Only handle horizontal scrolling when there's overflow
+                const hasHorizontalScroll = scroller.scrollWidth > scroller.clientWidth;
+                if (!hasHorizontalScroll) return;
+                
+                // Prevent vertical page scroll and enable horizontal scroll
+                if (Math.abs(e.deltaX) > 0 || Math.abs(e.deltaY) > 0) {
+                    e.preventDefault();
+                    const delta = e.deltaX || e.deltaY;
+                    scroller.scrollBy({
+                        left: delta,
+                        behavior: 'auto'
+                    });
+                }
+            }, { passive: false });
+        }
+
+        window.addEventListener('resize', updateButtons);
+        window.addEventListener('load', updateButtons);
+        
+        if (document.fonts?.ready) {
+            try {
+                document.fonts.ready.then(() => {
+                    setTimeout(updateButtons, 100);
+                });
+            } catch (e) {
+                // Fallback
+                setTimeout(updateButtons, 100);
+            }
+        }
+
+        // Multiple timing checks to ensure layout is ready
+        setTimeout(updateButtons, 50);
+        setTimeout(updateButtons, 200);
+        setTimeout(updateButtons, 500);
+        updateButtons();
+
+        // Playlist tab clicking
+        const tabs = tabsbar.querySelectorAll('.au-pl-tab');
+
+        // Remove existing handler to prevent duplicates
+        if (tabsbar._clickHandler) {
+            tabsbar.removeEventListener('click', tabsbar._clickHandler);
+        }
+
+        tabsbar._clickHandler = function(e) {
+            const tab = e.target?.closest('.au-pl-tab');
+            if (!tab || !tabsbar.contains(tab)) return;
+
+            e.preventDefault();
+            e.stopPropagation();
+
+            tabs.forEach(t => t.classList.toggle('is-active', t === tab));
+
+            const playlistId = tab.getAttribute('data-pl');
+            const titleOnlyContainer = card.querySelector('.au-playlists .au-pl-wrap--title-only');
+            const fullWraps = card.querySelectorAll('.au-playlists .au-pl-wrap--full');
+            
+            if (playlistId === 'all') {
+                // Show title-only grid for "All" tab
+                if (titleOnlyContainer) {
+                    titleOnlyContainer.style.display = 'grid';
+                }
+                fullWraps.forEach(wrap => {
+                    wrap.style.display = 'none';
+                });
+            } else {
+                // Hide title-only grid and show specific full playlist
+                if (titleOnlyContainer) {
+                    titleOnlyContainer.style.display = 'none';
+                }
+                fullWraps.forEach(wrap => {
+                    if (String(wrap.getAttribute('data-pl-id')) === playlistId) {
+                        wrap.style.display = 'block';
+                    } else {
+                        wrap.style.display = 'none';
+                    }
+                });
+                
+                // Also hide any remaining title-only items that might be visible
+                const allTitleOnlyItems = card.querySelectorAll('.au-playlists .copella-playlist--title-only');
+                allTitleOnlyItems.forEach(item => {
+                    item.style.display = 'none';
+                });
+                
+                // Hide any other playlist containers that might be showing
+                const allPlaylistContainers = card.querySelectorAll('.au-playlists .au-pl-wrap');
+                allPlaylistContainers.forEach(container => {
+                    if (!container.classList.contains('au-pl-wrap--full') || 
+                        String(container.getAttribute('data-pl-id')) !== playlistId) {
+                        container.style.display = 'none';
+                    }
+                });
+            }
+        };
+
+        tabsbar.addEventListener('click', tabsbar._clickHandler);
+    }
+
+    // Auto-initialize all author containers when DOM is ready
+    function initializeAll() {
+        const containers = document.querySelectorAll('.copella-authors');
+        containers.forEach(initAuthorContainer);
+    }
+
+    // Initialize when DOM is ready
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initializeAll);
+    } else {
+        initializeAll();
+    }
+
+    // Re-initialize when new content is dynamically added
+    if (typeof window.MutationObserver !== 'undefined') {
+        const pageObserver = new MutationObserver(mutations => {
+            mutations.forEach(mutation => {
+                mutation.addedNodes.forEach(node => {
+                    if (node.nodeType === 1) { // Element node
+                        if (node.classList?.contains('copella-authors')) {
+                            initAuthorContainer(node);
+                        } else {
+                            const containers = node.querySelectorAll?.('.copella-authors');
+                            containers?.forEach(initAuthorContainer);
+                        }
+                    }
+                });
+            });
+        });
+
+        pageObserver.observe(document.body, {
+            childList: true,
+            subtree: true
+        });
+    }
+
+    // Export for potential manual initialization
+    window.CopellaAuthors = {
+        init: initAuthorContainer,
+        initAll: initializeAll
+    };
+})();

--- a/plugin2/topics-playlists-plugin/assets/js/playlist-admin.js
+++ b/plugin2/topics-playlists-plugin/assets/js/playlist-admin.js
@@ -1,0 +1,150 @@
+(function($){
+  $(function(){ if(window.console){ console.log('[Copella] playlist admin script loaded'); }});
+  function renderResults(items){
+    var $box = $('#cp-pl-search-results').empty();
+    if(!items || !items.length){
+      $box.text(CopellaPlAdmin.i18n.nothingFound).show();
+      return;
+    }
+    var $list = $('<div/>');
+    items.forEach(function(it){
+      var $row = $('<div class="cp-pl-row" style="display:flex;align-items:center;gap:8px;margin:6px 0;"/>');
+      var $thumb = it.thumb ? $('<img/>',{src:it.thumb, width:40, height:40, style:'object-fit:cover;border-radius:6px;'}) : $('<span/>');
+      var $title = $('<span/>').text(it.title + ' (#' + it.id + ')');
+      var $date = it.date ? $('<span/>',{style:'opacity:.7;margin-left:auto;'}).text(it.date) : $('<span/>');
+      $row.append($thumb,$title,$date);
+      $list.append($row);
+    });
+    $box.append($list).show();
+  }
+
+  function doSearch(){
+    if(window.console){ console.log('[Copella] doSearch click'); }
+    var data = {
+      action: 'copella_playlist_search',
+      nonce: CopellaPlAdmin.nonce,
+      s: $('#cp-pl-search-q').val() || '',
+      post_type: $('#cp-pl-search-pt').val() || 'post',
+      tax: $('#cp-pl-search-tax').val() || '',
+      terms: $('#cp-pl-search-terms').val() || '',
+      limit: 50
+    };
+    $('#cp-pl-search-results').text('…').show();
+    $.post(CopellaPlAdmin.ajaxUrl, data, function(resp){
+      if(window.console){ console.log('[Copella] search response', resp); }
+      if(!resp || !resp.success){ renderResults([]); return; }
+      var items = resp.data.items || [];
+      renderResults(items);
+      var links = items.map(function(it){ return it.link; }).filter(Boolean);
+      $('#cp-pl-search-results').data('cpLinks', links);
+    });
+  }
+
+  function resolveTextarea(){
+    var el = document.getElementById('copella_playlist_items');
+    if(!el){ el = document.querySelector('textarea[name="copella_playlist_items"]'); }
+    return el ? $(el) : $();
+  }
+
+  function addSelected(){
+    var ids = [];
+    $('#cp-pl-search-results .cp-pl-pick:checked').each(function(){ ids.push($(this).val()); });
+    if(window.console){ console.log('[Copella] addSelected: checked', ids.length, ids); }
+    if(!ids.length){
+      // Показать явную подсказку, если ничего не выбрано
+      alert('Не выбрано ни одной записи. Поставьте галочки в списке выше.');
+      return;
+    }
+    var $ta = resolveTextarea();
+    if($ta.length === 0){ if(window.console){ console.log('[Copella] textarea not found'); } return; }
+    var before = ($ta.val() || '').toString();
+    var currentTrim = before.trim();
+    var currentLines = currentTrim ? currentTrim.split(/\r?\n/) : [];
+    var set = {};
+    currentLines.forEach(function(l){ set[l.trim()] = true; });
+    ids.forEach(function(id){ if(!set[id]){ currentLines.push(id); set[id] = true; } });
+    var addition = currentLines.join('\n').replace(/\n{3,}/g,'\n\n');
+    if(before && !/\n$/.test(before)) addition = '\n' + addition; // добавим перевод строки перед пачкой
+    var after = before + addition;
+    // Устанавливаем значение через jQuery и напрямую на DOM-элемент
+    $ta.val(after);
+    if($ta[0]){
+      $ta[0].value = after;
+      try{ $ta[0].dispatchEvent(new Event('input', { bubbles:true })); }catch(_){}}
+    try{ $ta[0].dispatchEvent(new Event('change', { bubbles:true })); }catch(_){}
+    // Scroll to textarea for feedback
+    $ta.focus();
+    // Визуальный отклик
+    $ta.css('box-shadow','0 0 0 2px #72aee6').delay(300).queue(function(nextq){ $(this).css('box-shadow',''); nextq(); });
+  }
+
+  $(document).on('click', '#cp-pl-search-btn', function(e){ e.preventDefault(); doSearch(); });
+  // New: copy all links button
+  $(document).on('click', '#cp-pl-copy-all', function(e){ e.preventDefault();
+    var items = $('#cp-pl-search-results').data('cpLinks') || [];
+    if(!items.length){ alert('Нет данных для копирования. Сначала нажмите «Найти».'); return; }
+    var text = items.join('\n');
+    if(navigator.clipboard && navigator.clipboard.writeText){ navigator.clipboard.writeText(text).then(function(){ alert('Ссылки скопированы в буфер обмена.'); }); }
+    else {
+      var ta = document.createElement('textarea'); ta.value = text; document.body.appendChild(ta); ta.select();
+      try{ document.execCommand('copy'); alert('Ссылки скопированы в буфер обмена.'); } finally { document.body.removeChild(ta); }
+    }
+  });
+})(jQuery);
+
+// Author picker script (vanilla to avoid double jQuery deps). Loaded on author edit screen inline.
+(function(){
+  if (typeof document === 'undefined') return;
+  function $(sel, root){ return (root||document).querySelector(sel); }
+  function $all(sel, root){ return Array.prototype.slice.call((root||document).querySelectorAll(sel)); }
+  function init(){
+    var root = document.querySelector('.cp-au-picker');
+    if(!root) return;
+    var input = $('#copella_author_playlists');
+    var search = $('#cp-au-search');
+    var rows = $all('.cp-au-row', root);
+    var picks = $all('.cp-au-pick', root);
+    var counter = $('#cp-au-picked-count');
+
+    function updateStore(){
+      var ids = picks.filter(function(ch){ return ch.checked; }).map(function(ch){ return ch.value; });
+      if(input){ input.value = ids.join(','); }
+      if(counter){ counter.textContent = 'Выбрано: ' + ids.length; }
+    }
+    picks.forEach(function(ch){ ch.addEventListener('change', updateStore); });
+
+    function applyFilter(){
+      var q = (search && search.value ? search.value : '').trim().toLowerCase();
+      rows.forEach(function(row){
+        var t = (row.getAttribute('data-title') || '').toLowerCase();
+        row.style.display = (!q || t.indexOf(q) !== -1) ? 'flex' : 'none';
+      });
+    }
+    if(search){ search.addEventListener('input', applyFilter); }
+  }
+  if(document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init); else init();
+})();
+
+// Author type toggling: hide/show stream vs video settings
+(function(){
+  if (typeof document === 'undefined') return;
+  function $(sel, root){ return (root||document).querySelector(sel); }
+  function $all(sel, root){ return Array.prototype.slice.call((root||document).querySelectorAll(sel)); }
+  function init(){
+    var typeRadios = $all('input[name="copella_author_type"]');
+    if (!typeRadios.length) return;
+    var videoBox = $('#cp-author-video-settings');
+    var streamBox = $('#cp-author-stream-settings');
+    function apply(){
+      var checked = typeRadios.find(function(r){ return r.checked; });
+      var val = checked ? checked.value : 'video';
+      if(videoBox){ videoBox.style.display = (val === 'video') ? '' : 'none'; }
+      if(streamBox){ streamBox.style.display = (val === 'stream') ? '' : 'none'; }
+    }
+    typeRadios.forEach(function(r){ r.addEventListener('change', apply); });
+    // initial
+    apply();
+  }
+  if(document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init); else init();
+})();
+

--- a/plugin2/topics-playlists-plugin/assets/js/playlist.js
+++ b/plugin2/topics-playlists-plugin/assets/js/playlist.js
@@ -1,0 +1,11 @@
+/**
+ * Copella Playlist JS
+ * Intentional no-op to avoid double-binding interactions.
+ * Inline scripts within the rendered shortcodes manage all behaviors.
+ */
+(function(){
+  // Guard: if inline init is present, do nothing
+  var anyInit = document.querySelector('.copella-playlist[data-pl-init]');
+  if (anyInit) { return; }
+  // If needed in the future, fallback behaviors can be added here
+})();

--- a/plugin2/topics-playlists-plugin/assets/js/topics.js
+++ b/plugin2/topics-playlists-plugin/assets/js/topics.js
@@ -1,0 +1,33 @@
+/**
+ * Copella Topics JS
+ * Progressive enhancement: smooth-scroll to block top on pagination click.
+ * Server-side pagination remains the source of truth.
+ */
+(function(){
+  document.addEventListener('click', function(e){
+    var a = e.target.closest('.copella-ht .ht-pagination a');
+    if(!a) return;
+    // Allow default navigation, but scroll to top of block after load
+    try {
+      var url = new URL(a.href);
+      url.hash = 'hot-topics';
+      a.href = url.toString();
+    } catch(_) {}
+  });
+  // If navigated with hash, nudge scroll into view
+  if (location.hash === '#hot-topics') {
+    var el = document.querySelector('.copella-ht');
+    if (el) {
+      setTimeout(function(){ el.scrollIntoView({behavior:'smooth', block:'start'}); }, 0);
+    }
+  }
+  
+  // Инициализация горизонтальной прокрутки для hot topics
+  var hotTopics = document.querySelectorAll('.copella-ht');
+  hotTopics.forEach(function(container) {
+    var track = container.querySelector('.ht-track');
+    if (track && track.scrollWidth > track.clientWidth) {
+      container.classList.add('has-scroll');
+    }
+  });
+})();

--- a/plugin2/topics-playlists-plugin/includes/admin.php
+++ b/plugin2/topics-playlists-plugin/includes/admin.php
@@ -1,0 +1,305 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Enqueue admin assets for playlist editor
+ */
+function copella_playlist_admin_enqueue(string $hook): void
+{
+    // Load only on post editor screens
+    if ($hook !== 'post.php' && $hook !== 'post-new.php') {
+        return;
+    }
+    $screen = get_current_screen();
+    if (!$screen || ($screen->post_type !== 'topic_playlist' && $screen->post_type !== 'topic_author')) {
+        return;
+    }
+
+    $js_path = COPELLA_TOPICS_PLUGIN_DIR . 'assets/js/playlist-admin.js';
+    wp_enqueue_script(
+        'copella-playlist-admin',
+        COPELLA_TOPICS_PLUGIN_URL . 'assets/js/playlist-admin.js',
+        array('jquery'),
+        file_exists($js_path) ? (string) filemtime($js_path) : '0.1.0',
+        true
+    );
+
+    wp_localize_script('copella-playlist-admin', 'CopellaPlAdmin', array(
+        'ajaxUrl' => admin_url('admin-ajax.php'),
+        'nonce'   => wp_create_nonce('copella_pl_search'),
+        'i18n'    => array(
+            'searchPlaceholder' => __('Поиск записей…', 'copella-topics'),
+            'searchButton'      => __('Найти', 'copella-topics'),
+            'addSelected'       => __('Добавить выбранные', 'copella-topics'),
+            'selectAll'         => __('Выбрать все', 'copella-topics'),
+            'nothingFound'      => __('Ничего не найдено', 'copella-topics'),
+        ),
+    ));
+}
+add_action('admin_enqueue_scripts', 'copella_playlist_admin_enqueue');
+
+/**
+ * AJAX: search posts to add into playlist
+ */
+function copella_playlist_ajax_search(): void
+{
+    if (!current_user_can('edit_posts')) {
+        wp_send_json_error(array('message' => 'forbidden'), 403);
+    }
+    check_ajax_referer('copella_pl_search', 'nonce');
+
+    $s = isset($_REQUEST['s']) ? sanitize_text_field((string) $_REQUEST['s']) : '';
+    $pt = isset($_REQUEST['post_type']) ? sanitize_text_field((string) $_REQUEST['post_type']) : 'post';
+    $tax = isset($_REQUEST['tax']) ? sanitize_text_field((string) $_REQUEST['tax']) : '';
+    $terms = isset($_REQUEST['terms']) ? sanitize_text_field((string) $_REQUEST['terms']) : '';
+    $limit = isset($_REQUEST['limit']) ? max(1, min(100, (int) $_REQUEST['limit'])) : 30;
+
+    $postTypes = array_filter(array_map('trim', explode(',', $pt ?: 'post')));
+    if (empty($postTypes)) { $postTypes = array('post'); }
+
+    $args = array(
+        'post_type'      => count($postTypes) === 1 ? $postTypes[0] : $postTypes,
+        'post_status'    => 'publish',
+        's'              => $s,
+        'posts_per_page' => $limit,
+        'orderby'        => 'date',
+        'order'          => 'DESC',
+        'no_found_rows'  => true,
+        'suppress_filters' => false,
+    );
+
+    $termSlugs = array_filter(array_map('trim', explode(',', $terms)));
+    if ($tax !== '' && !empty($termSlugs)) {
+        $args['tax_query'] = array(
+            array(
+                'taxonomy' => $tax,
+                'field'    => 'slug',
+                'terms'    => $termSlugs,
+                'operator' => 'IN',
+            )
+        );
+    }
+
+    $q = new WP_Query($args);
+    $items = array();
+    if ($q->have_posts()) {
+        while ($q->have_posts()) { $q->the_post();
+            $pid = get_the_ID();
+            $items[] = array(
+                'id'    => $pid,
+                'title' => get_the_title($pid),
+                'link'  => get_permalink($pid),
+                'thumb' => get_the_post_thumbnail_url($pid, 'thumbnail'),
+                'date'  => get_the_date('', $pid),
+            );
+        }
+        wp_reset_postdata();
+    }
+
+    wp_send_json_success(array('items' => $items));
+}
+add_action('wp_ajax_copella_playlist_search', 'copella_playlist_ajax_search');
+
+// Button on Projects (Authors) list to create Author Page (special page with shortcode)
+add_action('restrict_manage_posts', function(string $post_type): void{
+    if ($post_type !== 'topic_author') return;
+    $url = admin_url('edit.php?post_type=topic_author&page=copella-author-create-page');
+    echo '<a href="' . esc_url($url) . '" class="page-title-action">' . esc_html__('Создать страницу автора', 'copella-topics') . '</a>';
+});
+
+add_action('admin_menu', function(): void{
+    add_submenu_page(
+        'edit.php?post_type=topic_author',
+        __('Создать страницу автора', 'copella-topics'),
+        __('Создать страницу автора', 'copella-topics'),
+        'edit_posts',
+        'copella-author-create-page',
+        function(): void {
+            if (!current_user_can('edit_posts')) { wp_die(__('Недостаточно прав', 'copella-topics')); }
+            $created = false; $page_id = 0;
+            if (isset($_POST['cp_author_page_nonce']) && wp_verify_nonce((string)$_POST['cp_author_page_nonce'], 'cp_author_page')) {
+                $aid = isset($_POST['author_id']) ? absint((string)$_POST['author_id']) : 0;
+                if ($aid > 0) {
+                    $title = get_the_title($aid);
+                    $shortcode = '[author_page id="' . $aid . '"]';
+                    $page_id = wp_insert_post([
+                        'post_title' => $title,
+                        'post_type' => 'page',
+                        'post_status' => 'draft',
+                        'post_content' => "<!-- wp:shortcode -->\n$shortcode\n<!-- /wp:shortcode -->",
+                    ]);
+                    if ($page_id && !is_wp_error($page_id)) { 
+                        update_post_meta($aid, COPELLA_AUTHOR_META_PAGE_ID, (int)$page_id);
+                        $created = true; 
+                    }
+                }
+            }
+            ?>
+            <div class="wrap">
+                <h1><?php echo esc_html__('Создать страницу автора', 'copella-topics'); ?></h1>
+                <?php if ($created): ?>
+                    <div class="updated"><p><?php echo sprintf(__('Страница создана: %s', 'copella-topics'), '<a href="' . esc_url(get_edit_post_link($page_id)) . '">' . esc_html(get_the_title($page_id)) . '</a>'); ?></p></div>
+                <?php endif; ?>
+                <form method="post">
+                    <?php wp_nonce_field('cp_author_page', 'cp_author_page_nonce'); ?>
+                    <p>
+                        <label for="cp_author_select"><strong><?php _e('Выберите автора', 'copella-topics'); ?></strong></label><br/>
+                        <select id="cp_author_select" name="author_id" style="min-width:260px">
+                            <?php
+                            $authors = get_posts(['post_type'=>'topic_author','post_status'=>'any','posts_per_page'=>200,'orderby'=>'title','order'=>'ASC']);
+                            foreach ($authors as $a) {
+                                echo '<option value="' . (int)$a->ID . '">' . esc_html($a->post_title) . ' (#' . (int)$a->ID . ')</option>';
+                            }
+                            ?>
+                        </select>
+                    </p>
+                    <p><button type="submit" class="button button-primary"><?php _e('Создать страницу', 'copella-topics'); ?></button></p>
+                </form>
+            </div>
+            <?php
+        }
+    );
+});
+
+// AJAX: cpplayer reports live status: on/off for project (topic_author)
+function copella_topics_report_live_ajax(): void
+{
+    $aid = isset($_POST['author_id']) ? absint((string) $_POST['author_id']) : 0;
+    $status = isset($_POST['status']) ? strtolower(sanitize_text_field((string) $_POST['status'])) : '';
+    if ($aid <= 0 || ($status !== 'on' && $status !== 'off')) {
+        wp_send_json_error(['message' => 'bad_args'], 400);
+    }
+    set_transient('copella_topics_live_' . $aid, $status === 'on' ? 1 : 0, 120);
+    wp_send_json_success(['ok' => 1]);
+}
+add_action('wp_ajax_nopriv_copella_topics_report_live', 'copella_topics_report_live_ajax');
+add_action('wp_ajax_copella_topics_report_live', 'copella_topics_report_live_ajax');
+
+// Register Help page under Playlists
+add_action('admin_menu', function(): void{
+    add_submenu_page(
+        'edit.php?post_type=topic_playlist',
+        __('Copella Topics — Справка', 'copella-topics'),
+        __('Справка', 'copella-topics'),
+        'edit_posts',
+        'copella-topics-help',
+        function(): void {
+            ?>
+            <div class="wrap copella-topics-help">
+                <h1>Copella Topics — Справка</h1>
+                <style>
+                    .copella-topics-help code{background:#f6f7f7;padding:2px 6px;border-radius:4px}
+                    .copella-topics-help pre{background:#f6f7f7;padding:10px 12px;border-radius:6px;overflow:auto}
+                    .copella-topics-help h2{margin-top:28px}
+                    .copella-topics-help ul{list-style:disc;padding-left:20px}
+                </style>
+
+                <h2>Шорткод горячих тем</h2>
+                <p><code>[hot_topics]</code></p>
+                <p>Параметры:</p>
+                <ul>
+                    <li><strong>title</strong> — заголовок блока.</li>
+                    <li><strong>posts_per_page</strong> — сколько тем выводить.</li>
+                    <li><strong>aspect_ratio</strong> — аспект карточки, например <code>1/1</code>, <code>4/3</code>.</li>
+                    <li><strong>card_radius</strong>, <strong>gap</strong>, <strong>container_radius</strong>, <strong>container_bg</strong>, <strong>card_placeholder</strong>.</li>
+                    <li><strong>stagger</strong> (true/false), <strong>stagger_offset</strong>.</li>
+                </ul>
+                <pre>[hot_topics title="Горячие темы" posts_per_page="10" aspect_ratio="1/1" gap="40"]</pre>
+
+                <h2>Шорткод плейлиста</h2>
+                <p><code>[topic_playlist]</code></p>
+                <p>Параметры (ручной режим):</p>
+                <ul>
+                    <li><strong>playlist_id</strong> — ID плейлиста (обязателен вне записи плейлиста).</li>
+                    <li><strong>title</strong> — заголовок (если пусто, берётся заголовок записи плейлиста).</li>
+                    <li><strong>layout</strong> — <code>list</code> или <code>grid</code>.</li>
+                    <li><strong>grid_min</strong> — минимальная ширина колонки в grid (по умолчанию 220).</li>
+                    <li><strong>aspect_ratio</strong>, <strong>card_radius</strong>, <strong>container_radius</strong>, <strong>container_bg</strong>.</li>
+                    <li><strong>cover</strong> (true/false) — показать обложку плейлиста, <strong>cover_align</strong> (<code>left</code>/<code>right</code>), <strong>cover_height</strong> (px), <strong>cover_radius</strong> (px).</li>
+                    <li><strong>collapsed</strong> (true/false) — стартовое состояние (по умолчанию свернут). Внутри блока авторов плейлисты отображаются <em>раскрытыми</em> и <em>без обложки</em>.</li>
+                </ul>
+                <pre>[topic_playlist playlist_id="123" layout="grid" grid_min="280" aspect_ratio="1/1"]</pre>
+                <pre>[topic_playlist playlist_id="123" cover="true" cover_align="right" cover_height="220" collapsed="false"]</pre>
+
+                <h2>Как заполнять плейлист</h2>
+                <ul>
+                    <li>Каждая строка — <strong>ID</strong> записи WordPress или <strong>ссылка</strong>.</li>
+                    <li>Строка, начинающаяся с <code>#</code>, создаёт <strong>заголовок группы</strong> (вкладку).</li>
+                    <li>Вверху метабокса есть инструмент «Поиск и добавление»: найдите записи, отметьте галочки и нажмите «Добавить выбранные» — ID добавятся в список автоматически.</li>
+                    <li>Если групп больше одной, плейлист автоматически покажет <strong>вкладки категорий</strong> с горизонтальной прокруткой.</li>
+                </ul>
+
+                <h2>CSS-утилиты для раскладки</h2>
+                <ul>
+                    <li><code>cp-grid-2</code> — строгая сетка из двух колонок (рекомендуется для двух плейлистов рядом). На ширине &lt; 1280px превращается в одну колонку.</li>
+                    <li><code>cp-masonry</code> — «колонки» (мейсонри). Может оставлять правую пустой при разной высоте блоков.</li>
+                </ul>
+                <p>Использование: добавьте класс к обёртке (например, блоку «Группа»), которая содержит два шорткода.</p>
+                <pre>&lt;div class="cp-grid-2"&gt;
+  [topic_playlist playlist_id="6150"]
+  [topic_playlist playlist_id="6136"]
+&lt;/div&gt;</pre>
+
+                <h2>Подсказки</h2>
+                <ul>
+                    <li>Для группирования внутри плейлиста используйте строки с <code># Заголовок</code>.</li>
+                    <li>Если сетка «grid» ведёт себя странно, убедитесь, что нет конфликтующих классов от темы/блоков.</li>
+                </ul>
+
+                <h2>Шорткод авторов (список)</h2>
+                <p><code>[playlist_authors]</code></p>
+                <p>Параметры:</p>
+                <ul>
+                    <li><strong>title</strong> — заголовок блока.</li>
+                    <li><strong>posts_per_page</strong> — сколько авторов выводить.</li>
+                    <li><strong>columns</strong> — кол-во колонок в сетке (1–4).</li>
+                    <li><strong>gap</strong> — отступ между карточками в сетке (px).</li>
+                    <li><strong>cover_ratio</strong> — соотношение сторон обложки автора (по умолчанию <code>16/9</code>).</li>
+                </ul>
+                <p>Пример:</p>
+                <pre>[playlist_authors]</pre>
+                <p>Авторы отображаются в сетке. Кнопка со стрелкой на карточке сворачивает/разворачивает описание и вложенные плейлисты.</p>
+
+                <h2>Шорткод одного автора</h2>
+                <p><code>[playlist_author]</code></p>
+                <p>Параметры:</p>
+                <ul>
+                    <li><strong>author_id</strong> — ID автора (обязателен вне записи автора).</li>
+                    <li><strong>cover_ratio</strong> — соотношение сторон обложки (по умолчанию <code>16/9</code>).</li>
+                </ul>
+                <pre>[playlist_author author_id="42" cover_ratio="16/9"]</pre>
+                <p>Внутри блока автора назначенные плейлисты рендерятся <em>без обложки</em> и сразу <em>раскрытыми</em>.</p>
+
+                <h2>Расширенный поиск</h2>
+                <p><code>[tp_search]</code> — красивая индексная страница результатов с релевантностью, подсветкой совпадений и пагинацией.</p>
+                <p>Параметры:</p>
+                <ul>
+                    <li><strong>post_types</strong> — список типов: <code>post,topic,page,topic_playlist</code>.</li>
+                    <li><strong>per_page</strong> — результатов на странице (по умолчанию 12, максимум 40).</li>
+                    <li><strong>sort</strong> — <code>relevance</code> или <code>date</code>.</li>
+                    <li><strong>placeholder</strong> — плейсхолдер строки поиска.</li>
+                </ul>
+                <p>Пример вставки: <code>[tp_search post_types="post,topic,page" per_page="12" sort="relevance"]</code></p>
+                <p><em>Алгоритм</em>: токенизация RU/EN, простое «стеммирование», фильтрация стоп-слов, оценка совпадений по заголовку/описанию/контенту/таксономиям, бонус за точное вхождение фразы, бонус «свежести» по дате. Результаты ранжируются по нормализованному скору.</p>
+
+                <h2>Категории авторов</h2>
+                <p>Для группировки авторов в режиме вкладок используется таксономия <strong>Категории авторов</strong> (<code>author_category</code>). Её можно редактировать в админке на экране «Авторы».</p>
+                <ul>
+                    <li>Назначьте авторам нужные категории.</li>
+                    <li>Используйте <code>categories</code> в шорткоде, чтобы ограничить набор вкладок по слагам.</li>
+                </ul>
+            </div>
+            <?php
+        }
+    );
+});
+
+// Add visible button on Authors list screen
+// moved to author-page-admin.php
+
+// Quick action: Create Author Page (button on authors list)
+// moved to author-page-admin.php
+

--- a/plugin2/topics-playlists-plugin/includes/author-page.php
+++ b/plugin2/topics-playlists-plugin/includes/author-page.php
@@ -1,0 +1,164 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+// Page meta for author page: social networks
+const COPELLA_AUTHORPAGE_META_SOCIAL = '_copella_authorpage_social';
+
+add_action('add_meta_boxes', function(): void{
+    add_meta_box(
+        'copella_authorpage_social',
+        __('Социальные сети автора', 'copella-topics'),
+        function(WP_Post $post): void {
+            $social_raw = (string) get_post_meta($post->ID, COPELLA_AUTHORPAGE_META_SOCIAL, true);
+            ?>
+            <p>
+                <label for="copella_authorpage_social"><strong><?php _e('Социальные сети (по одной в строке)', 'copella-topics'); ?></strong></label><br/>
+                <textarea id="copella_authorpage_social" name="copella_authorpage_social" class="widefat" rows="4" placeholder="YouTube | https://youtube.com/@username | 🎥&#10;Telegram | https://t.me/username | 📱&#10;Instagram | https://instagram.com/username | 📸"><?php echo esc_textarea($social_raw); ?></textarea>
+            </p>
+            <p style="opacity:.8;margin-top:-4px"><?php _e('Формат: Название | Ссылка | Иконка (эмодзи или текст). Иконка необязательна.', 'copella-topics'); ?></p>
+            <?php
+        },
+        'page',
+        'normal',
+        'default'
+    );
+});
+
+add_action('save_post_page', function(int $post_id): void{
+    if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) return;
+    if (!current_user_can('edit_post', $post_id)) return;
+    if (isset($_POST['copella_authorpage_social'])) {
+        $raw = (string) $_POST['copella_authorpage_social'];
+        // Save as-is; validation happens on render
+        update_post_meta($post_id, COPELLA_AUTHORPAGE_META_SOCIAL, $raw);
+    }
+});
+
+// Shortcode: [author_page] — full author page built from a WP Page
+add_shortcode('author_page', function($atts): string {
+    $a = shortcode_atts([
+        'id' => '0',
+        'page_id' => '0',
+    ], $atts, 'author_page');
+
+    $pid = (int) ($a['id'] ?: $a['page_id']);
+    if ($pid <= 0) {
+        $pid = get_the_ID();
+    }
+    if ($pid <= 0) return '';
+
+    $name = get_the_title($pid);
+    $avatar = get_the_post_thumbnail_url($pid, 'thumbnail');
+    $desc = get_post_field('post_excerpt', $pid);
+    if ($desc === '') {
+        $raw = get_post_field('post_content', $pid);
+        $desc = wp_trim_words(wp_strip_all_tags($raw), 40, '…');
+    }
+    $social_raw = (string) get_post_meta($pid, COPELLA_AUTHORPAGE_META_SOCIAL, true);
+    $social_networks = [];
+    if ($social_raw !== '') {
+        $lines = array_filter(array_map('trim', preg_split("/\r\n|\r|\n/", $social_raw)));
+        foreach ($lines as $line) {
+            $parts = array_map('trim', explode('|', $line));
+            if (count($parts) >= 2) {
+                $social_networks[] = [
+                    'name' => sanitize_text_field($parts[0]),
+                    'url'  => esc_url($parts[1]),
+                    'icon' => isset($parts[2]) ? sanitize_text_field($parts[2]) : ''
+                ];
+            }
+        }
+    }
+
+    // Collect projects linked to this author page (topic_author with meta page_id = current page)
+    $projects = get_posts([
+        'post_type' => 'topic_author',
+        'post_status' => 'publish',
+        'meta_key' => COPELLA_AUTHOR_META_PAGE_ID,
+        'meta_value' => $pid,
+        'posts_per_page' => 200,
+        'orderby' => 'title',
+        'order' => 'ASC',
+    ]);
+    $videos = [];
+    $streams = [];
+    foreach ($projects as $prj) {
+        $type = (string) get_post_meta($prj->ID, COPELLA_AUTHOR_META_TYPE, true);
+        if ($type !== 'stream') $videos[] = $prj; else $streams[] = $prj;
+    }
+
+    ob_start();
+    ?>
+    <section class="copella-author-page" id="copella-authorpage-<?php echo (int)$pid; ?>">
+        <header class="ap-header">
+            <?php if ($avatar): ?><img class="ap-avatar" src="<?php echo esc_url($avatar); ?>" alt="" loading="lazy"/><?php endif; ?>
+            <div class="ap-head">
+                <h1 class="ap-name"><?php echo esc_html($name); ?></h1>
+                <?php if (!empty($desc)): ?><div class="ap-desc"><?php echo esc_html($desc); ?></div><?php endif; ?>
+            </div>
+        </header>
+
+        <?php if (!empty($videos)): ?>
+        <section class="ap-section ap-projects-video">
+            <h2 class="ap-section-title"><?php echo esc_html__('Видео', 'copella-topics'); ?></h2>
+            <div class="ap-cards">
+                <?php foreach ($videos as $prj): ?>
+                    <a class="ap-card" href="<?php echo esc_url(get_permalink($prj->ID)); ?>">
+                        <?php $pth = get_the_post_thumbnail_url($prj->ID, 'thumbnail'); if ($pth): ?><img class="ap-card-thumb" src="<?php echo esc_url($pth); ?>" alt=""/><?php endif; ?>
+                        <div class="ap-card-info">
+                            <div class="ap-card-title"><?php echo esc_html(get_the_title($prj->ID)); ?></div>
+                            <div class="ap-card-cat"><?php echo esc_html__('Видео', 'copella-topics'); ?></div>
+                        </div>
+                    </a>
+                <?php endforeach; ?>
+            </div>
+        </section>
+        <?php endif; ?>
+
+        <?php if (!empty($streams)): ?>
+        <section class="ap-section ap-projects-stream">
+            <h2 class="ap-section-title"><?php echo esc_html__('Стримы', 'copella-topics'); ?></h2>
+            <div class="ap-cards">
+                <?php foreach ($streams as $prj): ?>
+                    <a class="ap-card" href="<?php echo esc_url(get_permalink($prj->ID)); ?>">
+                        <?php $pth = get_the_post_thumbnail_url($prj->ID, 'thumbnail'); if ($pth): ?><img class="ap-card-thumb" src="<?php echo esc_url($pth); ?>" alt=""/><?php endif; ?>
+                        <div class="ap-card-info">
+                            <div class="ap-card-title"><?php echo esc_html(get_the_title($prj->ID)); ?></div>
+                            <div class="ap-card-cat"><?php echo esc_html__('Стримы', 'copella-topics'); ?></div>
+                        </div>
+                    </a>
+                <?php endforeach; ?>
+            </div>
+        </section>
+        <?php endif; ?>
+
+        <?php if (!empty($social_networks)): ?>
+        <section class="ap-section ap-socials">
+            <h2 class="ap-section-title"><?php echo esc_html__('Социальные сети', 'copella-topics'); ?></h2>
+            <ul class="ap-social-list">
+                <?php foreach ($social_networks as $sn): ?>
+                <li><a href="<?php echo esc_url($sn['url']); ?>" target="_blank" rel="noopener noreferrer"><?php echo $sn['icon'] ? esc_html($sn['icon']) . ' ' : ''; ?><?php echo esc_html($sn['name']); ?></a></li>
+                <?php endforeach; ?>
+            </ul>
+        </section>
+        <?php endif; ?>
+    </section>
+    <style>
+    .copella-author-page .ap-header{display:flex;gap:16px;align-items:center;margin-bottom:16px}
+    .copella-author-page .ap-avatar{width:96px;height:96px;border-radius:50%;object-fit:cover;border:2px solid rgba(0,0,0,.1)}
+    .copella-author-page .ap-name{margin:0 0 6px 0}
+    .copella-author-page .ap-desc{opacity:.9}
+    .copella-author-page .ap-section{margin:24px 0}
+    .copella-author-page .ap-cards{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:12px}
+    .copella-author-page .ap-card{display:flex;gap:10px;align-items:center;padding:8px 10px;border:1px solid #e5e5e5;border-radius:10px;background:#fff;text-decoration:none;color:inherit}
+    .copella-author-page .ap-card-thumb{width:42px;height:42px;border-radius:8px;object-fit:cover}
+    .copella-author-page .ap-card-title{font-weight:600}
+    .copella-author-page .ap-card-cat{font-size:.9em;opacity:.75}
+    .copella-author-page .ap-social-list{list-style:none;padding:0;margin:0;display:flex;gap:12px;flex-wrap:wrap}
+    .copella-author-page .ap-social-list a{text-decoration:none}
+    </style>
+    <?php
+    return ob_get_clean();
+});
+
+

--- a/plugin2/topics-playlists-plugin/includes/cpt.php
+++ b/plugin2/topics-playlists-plugin/includes/cpt.php
@@ -1,0 +1,118 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+function copella_topics_register_cpt(): void
+{
+    $labels = array(
+        'name'               => __('Темы', 'copella-topics'),
+        'singular_name'      => __('Тема', 'copella-topics'),
+        'menu_name'          => __('Темы', 'copella-topics'),
+        'name_admin_bar'     => __('Тема', 'copella-topics'),
+        'add_new'            => __('Добавить тему', 'copella-topics'),
+        'add_new_item'       => __('Добавить новую тему', 'copella-topics'),
+        'new_item'           => __('Новая тема', 'copella-topics'),
+        'edit_item'          => __('Редактировать тему', 'copella-topics'),
+        'view_item'          => __('Просмотреть тему', 'copella-topics'),
+        'all_items'          => __('Все темы', 'copella-topics'),
+        'search_items'       => __('Искать темы', 'copella-topics'),
+        'parent_item_colon'  => __('Родительские темы:', 'copella-topics'),
+        'not_found'          => __('Тем не найдено.', 'copella-topics'),
+        'not_found_in_trash' => __('В корзине тем не найдено.', 'copella-topics'),
+    );
+
+    // Support for title, thumbnail, and editor (Gutenberg)
+    $supports = array('title', 'thumbnail', 'editor');
+
+    register_post_type('topic', array(
+        'labels' => $labels,
+        'public' => true,
+        'has_archive' => true,
+        'rewrite' => array('slug' => 'topics'),
+        'menu_icon' => 'dashicons-playlist-audio',
+        'supports' => $supports,
+        'show_in_rest' => true,
+    ));
+
+    $pl_labels = array(
+        'name'               => __('Плейлисты', 'copella-topics'),
+        'singular_name'      => __('Плейлист', 'copella-topics'),
+        'menu_name'          => __('Плейлисты', 'copella-topics'),
+        'add_new'            => __('Добавить плейлист', 'copella-topics'),
+        'add_new_item'       => __('Добавить новый плейлист', 'copella-topics'),
+        'new_item'           => __('Новый плейлист', 'copella-topics'),
+        'edit_item'          => __('Редактировать плейлист', 'copella-topics'),
+        'view_item'          => __('Просмотреть плейлист', 'copella-topics'),
+        'all_items'          => __('Все плейлисты', 'copella-topics'),
+        'search_items'       => __('Искать плейлисты', 'copella-topics'),
+        'not_found'          => __('Плейлистов не найдено.', 'copella-topics'),
+    );
+    register_post_type('topic_playlist', array(
+        'labels' => $pl_labels,
+        'public' => false,
+        'show_ui' => true,
+        'show_in_menu' => true,
+        'menu_icon' => 'dashicons-list-view',
+        'supports' => array('title', 'thumbnail'),
+        'show_in_rest' => true,
+    ));
+
+    // Authors CPT
+    $au_labels = array(
+        'name'               => __('Авторы', 'copella-topics'),
+        'singular_name'      => __('Автор', 'copella-topics'),
+        'menu_name'          => __('Авторы', 'copella-topics'),
+        'add_new'            => __('Добавить автора', 'copella-topics'),
+        'add_new_item'       => __('Добавить нового автора', 'copella-topics'),
+        'new_item'           => __('Новый автор', 'copella-topics'),
+        'edit_item'          => __('Редактировать автора', 'copella-topics'),
+        'view_item'          => __('Просмотреть автора', 'copella-topics'),
+        'all_items'          => __('Все авторы', 'copella-topics'),
+        'search_items'       => __('Искать авторов', 'copella-topics'),
+        'not_found'          => __('Авторов не найдено.', 'copella-topics'),
+    );
+    register_post_type('topic_author', array(
+        'labels' => $au_labels,
+        'public' => true,
+        'show_ui' => true,
+        'show_in_menu' => true,
+        'menu_icon' => 'dashicons-groups',
+        // No editor; we allow excerpt for short bio and thumbnail for avatar
+        'supports' => array('title', 'thumbnail', 'excerpt'),
+        'show_in_rest' => true,
+        'has_archive' => true,
+        'rewrite' => array('slug' => 'authors'),
+    ));
+
+    // Register author_category taxonomy for grouping authors
+    $cat_labels = array(
+        'name'              => __('Категории авторов', 'copella-topics'),
+        'singular_name'     => __('Категория автора', 'copella-topics'),
+        'menu_name'         => __('Категории авторов', 'copella-topics'),
+        'search_items'      => __('Поиск категорий', 'copella-topics'),
+        'all_items'         => __('Все категории', 'copella-topics'),
+        'parent_item'       => __('Родительская категория', 'copella-topics'),
+        'parent_item_colon' => __('Родительская категория:', 'copella-topics'),
+        'edit_item'         => __('Редактировать категорию', 'copella-topics'),
+        'update_item'       => __('Обновить категорию', 'copella-topics'),
+        'add_new_item'      => __('Добавить новую категорию', 'copella-topics'),
+        'new_item_name'     => __('Название новой категории', 'copella-topics'),
+    );
+    
+    register_taxonomy('author_category', 'topic_author', array(
+        'hierarchical'      => true,
+        'labels'            => $cat_labels,
+        'show_ui'           => true,
+        'show_admin_column' => true,
+        'query_var'         => true,
+        'show_in_rest'      => true,
+        'rewrite'           => array('slug' => 'author-category'),
+    ));
+
+    // Removed legacy author_category taxonomy registration
+}
+
+add_action('init', 'copella_topics_register_cpt');
+

--- a/plugin2/topics-playlists-plugin/includes/helpers.php
+++ b/plugin2/topics-playlists-plugin/includes/helpers.php
@@ -1,0 +1,259 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Get author description with fallback to excerpt
+ */
+function copella_topics_get_author_desc(int $author_id, bool $fallback_to_excerpt = true): string
+{
+    $desc = (string) get_post_meta($author_id, COPELLA_AUTHOR_META_DESC, true);
+    if ($desc === '' && $fallback_to_excerpt) {
+        $desc = (string) get_the_excerpt($author_id);
+    }
+    return $desc;
+}
+
+/**
+ * Get author playlist IDs as an array of integers
+ */
+function copella_topics_get_author_playlist_ids(int $author_id): array
+{
+    $ids_raw = (string) get_post_meta($author_id, COPELLA_AUTHOR_META_PLAYLISTS, true);
+    return array_filter(array_map('absint', preg_split("/\r\n|\r|\n|,|\s+/", $ids_raw)));
+}
+
+/**
+ * Render author's playlists area: optional tabsbar + playlist embeds
+ */
+function copella_topics_render_author_playlists(array $playlist_ids, bool $with_tabsbar = true, bool $is_individual_tab = false): string
+{
+    if (empty($playlist_ids)) {
+        return '<div class="au-empty">' . esc_html__('Плейлисты не назначены.', 'copella-topics') . '</div>';
+    }
+    
+    $single_playlist = count($playlist_ids) === 1;
+    
+    ob_start();
+    ?>
+    <?php if (count($playlist_ids) > 1 && $with_tabsbar): ?>
+        <div class="au-pl-tabsbar" aria-label="<?php echo esc_attr__('Плейлисты автора', 'copella-topics'); ?>">
+            <button class="au-pl-tabs-nav au-pl-prev" type="button" aria-label="<?php echo esc_attr__('Назад', 'copella-topics'); ?>" title="<?php echo esc_attr__('Назад', 'copella-topics'); ?>">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M15 5L8 12L15 19" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </button>
+            <div class="au-pl-tabs-viewport">
+                <div class="au-pl-tabs" role="tablist">
+                    <button type="button" class="au-pl-tab is-active" data-pl="all"><?php echo esc_html__('Все', 'copella-topics'); ?></button>
+                    <?php foreach ($playlist_ids as $pid): ?>
+                        <button type="button" class="au-pl-tab" data-pl="<?php echo (int) $pid; ?>"><?php echo esc_html(wp_trim_words(get_the_title($pid), 3, '...')); ?></button>
+                    <?php endforeach; ?>
+                </div>
+            </div>
+            <button class="au-pl-tabs-nav au-pl-next" type="button" aria-label="<?php echo esc_attr__('Вперед', 'copella-topics'); ?>" title="<?php echo esc_attr__('Вперед', 'copella-topics'); ?>">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M9 5L16 12L9 19" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </button>
+        </div>
+    <?php endif; ?>
+    
+    <?php if ($single_playlist && $with_tabsbar): ?>
+        <!-- Single playlist: show content directly without tabs -->
+        <div class="au-playlists au-playlists--single">
+            <div class="au-pl-wrap--full au-pl-wrap--single" data-pl-id="<?php echo (int) $playlist_ids[0]; ?>">
+                <?php echo do_shortcode('[topic_playlist playlist_id="' . (int) $playlist_ids[0] . '" collapsed="false" cover="false" aspect_ratio="1/1"]'); ?>
+            </div>
+        </div>
+    <?php else: ?>
+        <!-- Multiple playlists: use tab system -->
+        <div class="au-playlists au-playlists--mixed">
+            <!-- Title-only version for "All" tab - single container with grid -->
+            <div class="au-pl-wrap--title-only">
+                <?php foreach ($playlist_ids as $pid): ?>
+                    <?php echo copella_topics_render_playlist_title_only($pid); ?>
+                <?php endforeach; ?>
+            </div>
+            
+            <!-- Full playlist versions for individual project tabs -->
+            <?php foreach ($playlist_ids as $pid): ?>
+                <div class="au-pl-wrap--full" data-pl-id="<?php echo (int) $pid; ?>" style="display: none;">
+                    <?php echo do_shortcode('[topic_playlist playlist_id="' . (int) $pid . '" collapsed="false" cover="false" aspect_ratio="1/1"]'); ?>
+                </div>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+    <?php
+    return (string) ob_get_clean();
+}
+
+/**
+ * Render social networks for an author
+ */
+function copella_topics_render_author_social_networks(int $author_id): string
+{
+    $social_raw = (string) get_post_meta($author_id, COPELLA_AUTHOR_META_SOCIAL, true);
+    if (empty($social_raw)) {
+        return '';
+    }
+    
+    $lines = array_filter(array_map('trim', preg_split("/\r\n|\r|\n/", $social_raw)));
+    if (empty($lines)) {
+        return '';
+    }
+    
+    $output = '<div class="au-social">';
+    foreach ($lines as $line) {
+        $parts = array_map('trim', explode('|', $line));
+        if (count($parts) < 2) {
+            continue;
+        }
+        
+        $name = $parts[0];
+        $url = $parts[1];
+        $icon = isset($parts[2]) ? $parts[2] : '';
+        
+        if (empty($name) || empty($url)) {
+            continue;
+        }
+        $isTelegram = (bool) preg_match('~(t\.me|telegram\.(me|org))~i', $url);
+        $output .= '<a href="' . esc_url($url) . '" class="au-social-link" target="_blank" rel="noopener noreferrer" title="' . esc_attr($name) . '">';
+        $isYouTube = (bool) preg_match('~(youtube\.com|youtu\.be)~i', $url);
+        if ($isYouTube) {
+            $ytLogo = COPELLA_TOPICS_PLUGIN_URL . 'assets/icons/youtube.svg';
+            $output .= '<span class="au-social-logo" aria-hidden="true"><img src="' . esc_url($ytLogo) . '" alt="" loading="lazy"/></span>';
+        }
+        if ($isTelegram) {
+            $tgLogo = 'https://copella.live/wp-content/uploads/2025/08/image_2025-08-16_19-21-48.png';
+            $output .= '<span class="au-social-logo" aria-hidden="true"><img src="' . esc_url($tgLogo) . '" alt="" loading="lazy"/></span>';
+        }
+        if (!empty($icon)) {
+            $output .= '<span class="au-social-icon">' . esc_html($icon) . '</span>';
+        }
+        $output .= '<span class="au-social-name">' . esc_html($name) . '</span>';
+        $output .= '</a>';
+    }
+    $output .= '</div>';
+    
+    return $output;
+}
+
+/**
+ * Fetch compact schedule summary for a CP Schedule channel.
+ * Returns associative array with keys: offline(bool), current(?array), upcoming(array of arrays)
+ */
+function copella_topics_fetch_tvschedule_summary(int $channelId, int $limit = 3): array
+{
+    $summary = array('offline' => false, 'current' => null, 'upcoming' => array());
+    if ($channelId <= 0) {
+        return $summary;
+    }
+    global $wpdb;
+    $table = $wpdb->prefix . 'tv_schedule';
+    // Ensure table exists
+    $exists = $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $table));
+    if ($exists !== $table) {
+        return $summary;
+    }
+    // Offline channels option
+    $offlineChannels = get_option('tvschedule_offline_channels', array());
+    $summary['offline'] = in_array($channelId, (array) $offlineChannels, true);
+    $currentDate = current_time('Y-m-d');
+    $currentTime = current_time('H:i:s');
+    // Current program <= now
+    $current = $wpdb->get_row($wpdb->prepare(
+        "SELECT program_time, program_name FROM {$table} WHERE channel_id = %d AND program_date = %s AND program_time <= %s ORDER BY program_time DESC LIMIT 1",
+        $channelId, $currentDate, $currentTime
+    ));
+    if ($current) {
+        $summary['current'] = array(
+            'time' => substr((string) $current->program_time, 0, 5),
+            'name' => (string) $current->program_name,
+        );
+    }
+    // Upcoming next N today > now
+    $limit = max(1, min(10, $limit));
+    $upcoming = $wpdb->get_results($wpdb->prepare(
+        "SELECT program_time, program_name FROM {$table} WHERE channel_id = %d AND program_date = %s AND program_time > %s ORDER BY program_time ASC LIMIT %d",
+        $channelId, $currentDate, $currentTime, $limit
+    ));
+    if (!empty($upcoming)) {
+        foreach ($upcoming as $row) {
+            $summary['upcoming'][] = array(
+                'time' => substr((string) $row->program_time, 0, 5),
+                'name' => (string) $row->program_name,
+            );
+        }
+    }
+    return $summary;
+}
+
+/**
+ * Render compact schedule summary markup for authors stream card
+ */
+function copella_topics_render_schedule_compact(array $data): string
+{
+    $offline = !empty($data['offline']);
+    $current = isset($data['current']) ? $data['current'] : null;
+    $upcoming = isset($data['upcoming']) && is_array($data['upcoming']) ? $data['upcoming'] : array();
+    ob_start();
+    ?>
+    <div class="au-program-mini">
+        <?php if ($offline): ?>
+            <div class="ap-offline"><?php echo esc_html__('Канал временно не вещает', 'copella-topics'); ?></div>
+        <?php else: ?>
+            <?php if (empty($current) && empty($upcoming)): ?>
+                <div class="ap-nodata">
+                    <span class="ap-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 6l12 12M18 6L6 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
+                    <span class="ap-text"><?php echo esc_html__('Не нашли подготовленной программы', 'copella-topics'); ?></span>
+                </div>
+            <?php else: ?>
+            <div class="ap-now">
+                <span class="ap-label"><?php echo esc_html__('Сейчас', 'copella-topics'); ?>:</span>
+                <?php if ($current): ?>
+                    <span class="ap-time"><?php echo esc_html((string) $current['time']); ?></span>
+                    <span class="ap-title"><?php echo esc_html((string) $current['name']); ?></span>
+                <?php else: ?>
+                    <span class="ap-empty"><?php echo esc_html__('Нет текущей программы', 'copella-topics'); ?></span>
+                <?php endif; ?>
+            </div>
+            <div class="ap-next">
+                <span class="ap-label"><?php echo esc_html__('Далее', 'copella-topics'); ?>:</span>
+                <?php if (!empty($upcoming)): ?>
+                    <ul class="ap-list">
+                        <?php foreach ($upcoming as $row): ?>
+                            <li><span class="ap-time"><?php echo esc_html((string) $row['time']); ?></span> <span class="ap-title"><?php echo esc_html((string) $row['name']); ?></span></li>
+                        <?php endforeach; ?>
+                    </ul>
+                <?php else: ?>
+                    <span class="ap-empty"><?php echo esc_html__('Нет данных', 'copella-topics'); ?></span>
+                <?php endif; ?>
+            </div>
+            <?php endif; ?>
+        <?php endif; ?>
+    </div>
+    <?php
+    return (string) ob_get_clean();
+}
+
+/**
+ * Render playlist title only (for "All" view - no episodes, no expansion)
+ */
+function copella_topics_render_playlist_title_only(int $playlist_id): string
+{
+    if ($playlist_id <= 0) {
+        return '';
+    }
+    
+    $title = get_the_title($playlist_id);
+    $uid = 'pl_title_' . wp_generate_password(8, false, false);
+    
+    ob_start();
+    ?>
+    <div id="<?php echo esc_attr($uid); ?>" class="copella-playlist copella-playlist--title-only" data-pl-init="1" style="--pl-container-bg:#171717;--pl-container-radius:28px;">
+        <div class="pl-header pl-header--no-expand">
+            <h3 class="pl-title"><?php echo esc_html($title); ?></h3>
+        </div>
+    </div>
+    <?php
+    return (string) ob_get_clean();
+}
+?>

--- a/plugin2/topics-playlists-plugin/includes/meta.php
+++ b/plugin2/topics-playlists-plugin/includes/meta.php
@@ -1,0 +1,437 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+
+const COPELLA_TOPICS_META_LINK      = '_copella_topic_link';
+const COPELLA_TOPICS_META_VIDEOS    = '_copella_topic_videos';
+const COPELLA_PLAYLIST_META_ITEMS   = '_copella_playlist_items';
+const COPELLA_AUTHOR_META_PLAYLISTS = '_copella_author_playlists';
+const COPELLA_AUTHOR_META_SOCIAL    = '_copella_author_social';
+const COPELLA_AUTHOR_META_DESC      = '_copella_author_desc';
+const COPELLA_AUTHOR_META_TYPE      = '_copella_author_type'; // 'video' | 'stream'
+const COPELLA_AUTHOR_META_STREAM_URL = '_copella_author_stream_url';
+const COPELLA_AUTHOR_META_IS_LIVE   = '_copella_author_is_live'; // '1' | '0'
+const COPELLA_AUTHOR_META_PROGRAM_ID = '_copella_author_program_id';
+const COPELLA_AUTHOR_META_STREAM_INFO = '_copella_author_stream_info';
+// New links
+const COPELLA_AUTHOR_META_PAGE_ID = '_copella_author_page_id';
+const COPELLA_AUTHOR_META_WP_USER_ID = '_copella_author_wp_user_id';
+
+function copella_topics_add_meta_boxes(): void
+{
+    add_meta_box(
+        'copella_topic_details',
+        __('Настройки темы', 'copella-topics'),
+        'copella_topics_render_meta_box',
+        'topic',
+        'normal',
+        'default'
+    );
+}
+add_action('add_meta_boxes', 'copella_topics_add_meta_boxes');
+
+function copella_topics_render_meta_box(WP_Post $post): void
+{
+    wp_nonce_field('copella_topics_meta', 'copella_topics_meta_nonce');
+    $link   = (string) get_post_meta($post->ID, COPELLA_TOPICS_META_LINK, true);
+    ?>
+    <p>
+        <label for="copella_topic_link"><strong><?php _e('Ссылка для темы (необязательно)', 'copella-topics'); ?></strong></label><br/>
+        <input type="url" id="copella_topic_link" name="copella_topic_link" value="<?php echo esc_attr($link); ?>" class="widefat" placeholder="https://example.com/страница-темы"/>
+    </p>
+    <p><em><?php _e('Плейлисты создаются отдельно в разделе «Плейлисты». Вставляйте их на страницу темы через шорткод из плейлиста.', 'copella-topics'); ?></em></p>
+    <?php
+}
+
+function copella_topics_save_meta_boxes(int $post_id): void
+{
+    if (!isset($_POST['copella_topics_meta_nonce']) || !wp_verify_nonce((string) $_POST['copella_topics_meta_nonce'], 'copella_topics_meta')) {
+        return;
+    }
+    if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+        return;
+    }
+    if (!current_user_can('edit_post', $post_id)) {
+        return;
+    }
+
+    $link = isset($_POST['copella_topic_link']) ? esc_url_raw((string) $_POST['copella_topic_link']) : '';
+    update_post_meta($post_id, COPELLA_TOPICS_META_LINK, $link);
+}
+add_action('save_post_topic', 'copella_topics_save_meta_boxes');
+
+function copella_playlist_add_meta_boxes(): void
+{
+    add_meta_box(
+        'copella_playlist_items',
+        __('Содержимое плейлиста', 'copella-topics'),
+        'copella_playlist_render_meta_box',
+        'topic_playlist',
+        'normal',
+        'default'
+    );
+}
+add_action('add_meta_boxes', 'copella_playlist_add_meta_boxes');
+
+function copella_playlist_render_meta_box(WP_Post $post): void
+{
+    wp_nonce_field('copella_playlist_meta', 'copella_playlist_meta_nonce');
+    $items = (string) get_post_meta($post->ID, COPELLA_PLAYLIST_META_ITEMS, true);
+    ?>
+    <div class="copella-pl-finder" style="padding:10px 12px;border:1px solid rgba(0,0,0,.1);border-radius:8px;background:#fff;margin:0 0 14px 0">
+        <p style="margin:0 0 8px 0"><strong><?php _e('Поиск и добавление записей в список', 'copella-topics'); ?></strong></p>
+        <div style="display:flex;gap:8px;flex-wrap:wrap;align-items:center;margin-bottom:8px">
+            <input type="text" id="cp-pl-search-q" class="regular-text" placeholder="<?php esc_attr_e('Поиск записей…', 'copella-topics'); ?>"/>
+            <input type="text" id="cp-pl-search-pt" class="regular-text" placeholder="post, topic" value="post"/>
+            <input type="text" id="cp-pl-search-tax" class="regular-text" placeholder="category"/>
+            <input type="text" id="cp-pl-search-terms" class="regular-text" placeholder="slugs: sezon-1,sezon-2"/>
+            <button type="button" class="button" id="cp-pl-search-btn"><?php _e('Найти', 'copella-topics'); ?></button>
+        </div>
+        <div id="cp-pl-search-results" style="max-height:260px;overflow:auto;border:1px solid #ddd;border-radius:6px;padding:8px;display:none"></div>
+        <div style="display:flex;gap:8px;margin-top:8px;align-items:center">
+            <button type="button" class="button button-primary" id="cp-pl-copy-all"><?php _e('Скопировать ссылки', 'copella-topics'); ?></button>
+            <span style="opacity:.75"><?php _e('Скопирует все найденные ссылки (по одной в строке) в буфер обмена.', 'copella-topics'); ?></span>
+        </div>
+    </div>
+    
+    <p>
+        <label for="copella_playlist_items"><strong><?php _e('Ссылки или ID записей (по одной в строке). Для категорий используйте заголовки с #', 'copella-topics'); ?></strong></label>
+        <textarea id="copella_playlist_items" name="copella_playlist_items" class="widefat" rows="10" placeholder="# 1 сезон\n123 | tag=Премьера | color=#FF653A\nhttps://site.com/post... | tag=Live | color=#00D084\n\n# 2 сезон\n456"><?php echo esc_textarea($items); ?></textarea>
+    </p>
+    <p style="opacity:.8;margin-top:-4px">
+        <?php _e('Можно добавлять метки для видео: допишите после ID/ссылки через вертикальную черту, например', 'copella-topics'); ?>
+        <code>123 | tag=Премьера | color=#FF653A</code>.
+    </p>
+    <p>
+        <label><strong><?php _e('Шорткод плейлиста', 'copella-topics'); ?></strong></label><br/>
+        <input type="text" readonly class="widefat" value="[topic_playlist playlist_id=&quot;<?php echo (int) $post->ID; ?>&quot;]" onclick="this.select();document.execCommand('copy');"/>
+    </p>
+    <?php
+}
+
+function copella_playlist_save_meta_boxes(int $post_id): void
+{
+    if (!isset($_POST['copella_playlist_meta_nonce']) || !wp_verify_nonce((string) $_POST['copella_playlist_meta_nonce'], 'copella_playlist_meta')) {
+        return;
+    }
+    if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+        return;
+    }
+    if (!current_user_can('edit_post', $post_id)) {
+        return;
+    }
+    $raw = isset($_POST['copella_playlist_items']) ? (string) $_POST['copella_playlist_items'] : '';
+    $lines = array_filter(array_map('trim', preg_split("/\r\n|\r|\n/", $raw)));
+    $store = implode("\n", $lines);
+    update_post_meta($post_id, COPELLA_PLAYLIST_META_ITEMS, $store);
+
+    // В упрощённом режиме сохраняем только текстовый список
+}
+add_action('save_post_topic_playlist', 'copella_playlist_save_meta_boxes');
+
+/**
+ * Author meta: select playlists for the author
+ */
+function copella_author_add_meta_boxes(): void
+{
+    add_meta_box(
+        'copella_author_type',
+        __('Тип автора', 'copella-topics'),
+        'copella_author_render_type_meta_box',
+        'topic_author',
+        'side',
+        'high'
+    );
+    add_meta_box(
+        'copella_author_playlists',
+        __('Плейлисты автора', 'copella-topics'),
+        'copella_author_render_meta_box',
+        'topic_author',
+        'normal',
+        'default'
+    );
+    add_meta_box(
+        'copella_author_desc',
+        __('Описание автора', 'copella-topics'),
+        'copella_author_render_desc_meta_box',
+        'topic_author',
+        'normal',
+        'default'
+    );
+    add_meta_box(
+        'copella_author_links',
+        __('Связи', 'copella-topics'),
+        'copella_author_render_links_meta_box',
+        'topic_author',
+        'side',
+        'default'
+    );
+    add_meta_box(
+        'copella_author_stream',
+        __('Настройки стрима', 'copella-topics'),
+        'copella_author_render_stream_meta_box',
+        'topic_author',
+        'normal',
+        'default'
+    );
+}
+add_action('add_meta_boxes', 'copella_author_add_meta_boxes');
+
+function copella_author_render_type_meta_box(WP_Post $post): void
+{
+    $type = (string) get_post_meta($post->ID, COPELLA_AUTHOR_META_TYPE, true);
+    if ($type !== 'stream' && $type !== 'video') { $type = 'video'; }
+    ?>
+    <p style="margin:0 0 8px 0"><strong><?php _e('Выберите тип автора', 'copella-topics'); ?></strong></p>
+    <p style="margin:0 0 8px 0">
+        <label><input type="radio" name="copella_author_type" value="video" <?php checked($type === 'video'); ?>/> <?php _e('Автор видео', 'copella-topics'); ?></label><br/>
+        <label><input type="radio" name="copella_author_type" value="stream" <?php checked($type === 'stream'); ?>/> <?php _e('Автор стрима', 'copella-topics'); ?></label>
+    </p>
+    
+    <?php
+}
+
+function copella_author_render_meta_box(WP_Post $post): void
+{
+    wp_nonce_field('copella_author_meta', 'copella_author_meta_nonce');
+    // Backup current excerpt to defend against accidental clearing during save
+    $current_excerpt = get_post_field('post_excerpt', $post->ID);
+    $ids_raw = (string) get_post_meta($post->ID, COPELLA_AUTHOR_META_PLAYLISTS, true);
+    $selected = array_filter(array_map('absint', preg_split("/\r\n|\r|\n|,|\s+/", $ids_raw)));
+    $selected_map = array_fill_keys($selected, true);
+    
+    $social_raw = (string) get_post_meta($post->ID, COPELLA_AUTHOR_META_SOCIAL, true);
+    $social_networks = array();
+    if (!empty($social_raw)) {
+        $lines = array_filter(array_map('trim', preg_split("/\r\n|\r|\n/", $social_raw)));
+        foreach ($lines as $line) {
+            $parts = array_map('trim', explode('|', $line));
+            if (count($parts) >= 2) {
+                $social_networks[] = array(
+                    'name' => $parts[0],
+                    'url' => $parts[1],
+                    'icon' => isset($parts[2]) ? $parts[2] : ''
+                );
+            }
+        }
+    }
+
+    $q = new WP_Query(array(
+        'post_type' => 'topic_playlist',
+        'post_status' => array('publish', 'draft', 'private'),
+        'posts_per_page' => 500,
+        'orderby' => 'date',
+        'order' => 'DESC',
+        'no_found_rows' => true,
+    ));
+    $items = array();
+    if ($q->have_posts()) {
+        while ($q->have_posts()) { $q->the_post();
+            $pid = get_the_ID();
+            $items[] = array(
+                'id' => $pid,
+                'title' => get_the_title($pid),
+                'thumb' => get_the_post_thumbnail_url($pid, 'thumbnail'),
+                'status' => get_post_status($pid),
+            );
+        }
+        wp_reset_postdata();
+    }
+    ?>
+    <div class="cp-au-picker" id="cp-author-video-settings" style="padding:10px 12px;border:1px solid rgba(0,0,0,.1);border-radius:8px;background:#fff;margin:0 0 14px 0">
+        <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:8px">
+            <input type="text" id="cp-au-search" class="regular-text" placeholder="<?php esc_attr_e('Поиск плейлистов…', 'copella-topics'); ?>"/>
+            <span style="opacity:.75"><?php printf(__('Всего: %d', 'copella-topics'), (int) count($items)); ?></span>
+            <span id="cp-au-picked-count" style="margin-left:auto;opacity:.75"><?php printf(__('Выбрано: %d', 'copella-topics'), (int) count($selected)); ?></span>
+        </div>
+        <div id="cp-au-list" style="max-height:320px;overflow:auto;border:1px solid #ddd;border-radius:6px;padding:8px;background:#fff">
+            <?php if (empty($items)): ?>
+                <div style="opacity:.7;padding:6px 0"><?php _e('Плейлистов не найдено.', 'copella-topics'); ?></div>
+            <?php else: foreach ($items as $pl): ?>
+                <label class="cp-au-row" data-title="<?php echo esc_attr(function_exists('mb_strtolower') ? mb_strtolower($pl['title'], 'UTF-8') : strtolower($pl['title'])); ?>" style="display:flex;align-items:center;gap:10px;margin:6px 0">
+                    <input type="checkbox" class="cp-au-pick" name="copella_author_picks[]" value="<?php echo (int) $pl['id']; ?>" <?php checked(isset($selected_map[$pl['id']])); ?>/>
+                    <?php if ($pl['thumb']): ?><img src="<?php echo esc_url($pl['thumb']); ?>" width="40" height="40" style="object-fit:cover;border-radius:6px" alt=""/><?php endif; ?>
+                    <span><?php echo esc_html($pl['title']); ?> <span style="opacity:.6">#<?php echo (int) $pl['id']; ?></span></span>
+                    <?php if ($pl['status'] !== 'publish'): ?><span style="margin-left:auto;opacity:.65;"><em><?php echo esc_html($pl['status']); ?></em></span><?php endif; ?>
+                </label>
+            <?php endforeach; endif; ?>
+        </div>
+        <input type="hidden" id="copella_author_playlists" name="copella_author_playlists" value="<?php echo esc_attr(implode(',', $selected)); ?>"/>
+    </div>
+    <p style="opacity:.8;margin:6px 0 0 0"><?php _e('Выберите плейлисты из списка выше. Поиск работает по заголовку.', 'copella-topics'); ?></p>
+    <input type="hidden" name="copella_author_excerpt_backup" value="<?php echo esc_attr($current_excerpt); ?>"/>
+    
+    <p>
+        <label for="copella_author_social"><strong><?php _e('Социальные сети (по одной в строке)', 'copella-topics'); ?></strong></label><br/>
+        <textarea id="copella_author_social" name="copella_author_social" class="widefat" rows="4" placeholder="YouTube | https://youtube.com/@username | 🎥&#10;Telegram | https://t.me/username | 📱&#10;Instagram | https://instagram.com/username | 📸"><?php 
+            if (!empty($social_networks)) {
+                foreach ($social_networks as $network) {
+                    echo esc_textarea($network['name'] . ' | ' . $network['url'] . ' | ' . $network['icon']) . "\n";
+                }
+            }
+        ?></textarea>
+    </p>
+    <p style="opacity:.8;margin-top:-4px">
+        <?php _e('Формат: Название | Ссылка | Иконка (эмодзи или текст). Иконка необязательна.', 'copella-topics'); ?>
+    </p>
+    
+    <p>
+        <label><strong><?php _e('Шорткод автора', 'copella-topics'); ?></strong></label><br/>
+        <input type="text" readonly class="widefat" value="[playlist_author author_id=&quot;<?php echo (int) $post->ID; ?>&quot;]" onclick="this.select();document.execCommand('copy');"/>
+    </p>
+    <?php
+}
+
+function copella_author_render_desc_meta_box(WP_Post $post): void
+{
+    $desc = (string) get_post_meta($post->ID, COPELLA_AUTHOR_META_DESC, true);
+    ?>
+    <p>
+        <label for="copella_author_desc"><strong><?php _e('Краткое описание (показывается в карточке автора)', 'copella-topics'); ?></strong></label><br/>
+        <textarea id="copella_author_desc" name="copella_author_desc" class="widefat" rows="4" placeholder="<?php echo esc_attr__('Краткое описание автора…', 'copella-topics'); ?>"><?php echo esc_textarea($desc); ?></textarea>
+    </p>
+    <?php
+}
+
+function copella_author_render_links_meta_box(WP_Post $post): void
+{
+    $page_id = (int) get_post_meta($post->ID, COPELLA_AUTHOR_META_PAGE_ID, true);
+    ?>
+    <p>
+        <label for="copella_author_page_id"><strong><?php _e('Страница автора', 'copella-topics'); ?></strong></label><br/>
+        <?php
+        wp_dropdown_pages([
+            'name' => 'copella_author_page_id',
+            'id' => 'copella_author_page_id',
+            'selected' => $page_id,
+            'show_option_none' => __('— Не выбрано —', 'copella-topics'),
+        ]);
+        ?>
+    </p>
+    <?php
+}
+
+function copella_author_render_stream_meta_box(WP_Post $post): void
+{
+    $program_id = (int) get_post_meta($post->ID, COPELLA_AUTHOR_META_PROGRAM_ID, true);
+    $stream_url = (string) get_post_meta($post->ID, COPELLA_AUTHOR_META_STREAM_URL, true);
+    $stream_info = (string) get_post_meta($post->ID, COPELLA_AUTHOR_META_STREAM_INFO, true);
+    $is_live = (string) get_post_meta($post->ID, COPELLA_AUTHOR_META_IS_LIVE, true) === '1';
+    ?>
+    <p>
+        <label for="copella_author_program_id"><strong><?php _e('ID программы передач', 'copella-topics'); ?></strong></label><br/>
+        <input type="number" id="copella_author_program_id" name="copella_author_program_id" value="<?php echo (int) $program_id; ?>" class="regular-text" min="0" placeholder="Например: 123"/>
+    </p>
+    <p style="opacity:.8;margin-top:-4px">
+        <?php _e('Укажите ID канала для отображения программы передач.', 'copella-topics'); ?>
+    </p>
+    
+    <p>
+        <label for="copella_author_stream_url"><strong><?php _e('Ссылка на стрим', 'copella-topics'); ?></strong></label><br/>
+        <input type="url" id="copella_author_stream_url" name="copella_author_stream_url" value="<?php echo esc_attr($stream_url); ?>" class="widefat" placeholder="https://example.com/stream"/>
+    </p>
+    
+    <p>
+        <label>
+            <input type="checkbox" id="copella_author_is_live" name="copella_author_is_live" value="1" <?php checked($is_live); ?>/>
+            <strong><?php _e('Стрим в эфире', 'copella-topics'); ?></strong>
+        </label>
+    </p>
+    <p style="opacity:.8;margin-top:-4px">
+        <?php _e('Отметьте, если стрим в данный момент вещает в прямом эфире.', 'copella-topics'); ?>
+    </p>
+    
+    <p>
+        <label for="copella_author_stream_info"><strong><?php _e('Дополнительная информация о стриме', 'copella-topics'); ?></strong></label><br/>
+        <textarea id="copella_author_stream_info" name="copella_author_stream_info" class="widefat" rows="3" placeholder="Описание стрима..."><?php echo esc_textarea($stream_info); ?></textarea>
+    </p>
+    <?php
+}
+
+function copella_author_save_meta_boxes(int $post_id): void
+{
+    if (!isset($_POST['copella_author_meta_nonce']) || !wp_verify_nonce((string) $_POST['copella_author_meta_nonce'], 'copella_author_meta')) {
+        return;
+    }
+    if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+        return;
+    }
+    if (!current_user_can('edit_post', $post_id)) {
+        return;
+    }
+    
+    // Сохраняем плейлисты
+    $ids = array();
+    if (isset($_POST['copella_author_picks']) && is_array($_POST['copella_author_picks'])) {
+        $ids = array_map('absint', (array) $_POST['copella_author_picks']);
+    } else {
+        $raw = isset($_POST['copella_author_playlists']) ? (string) $_POST['copella_author_playlists'] : '';
+        $ids = array_filter(array_map('absint', preg_split("/\r\n|\r|\n|,|\s+/", $raw)));
+    }
+    $ids = array_values(array_unique(array_filter($ids)));
+    $store = implode(",", $ids);
+    update_post_meta($post_id, COPELLA_AUTHOR_META_PLAYLISTS, $store);
+    
+    // Сохраняем социальные сети
+    $social_raw = isset($_POST['copella_author_social']) ? (string) $_POST['copella_author_social'] : '';
+    $lines = array_filter(array_map('trim', preg_split("/\r\n|\r|\n/", $social_raw)));
+    $social_networks = array();
+    
+    foreach ($lines as $line) {
+        $parts = array_map('trim', explode('|', $line));
+        if (count($parts) >= 2) {
+            $name = sanitize_text_field($parts[0]);
+            $url = esc_url_raw($parts[1]);
+            $icon = isset($parts[2]) ? sanitize_text_field($parts[2]) : '';
+            
+            if (!empty($name) && !empty($url)) {
+                $social_networks[] = $name . ' | ' . $url . ($icon ? ' | ' . $icon : '');
+            }
+        }
+    }
+    
+    $social_store = implode("\n", $social_networks);
+    update_post_meta($post_id, COPELLA_AUTHOR_META_SOCIAL, $social_store);
+
+    // Save separate author description meta
+    if (isset($_POST['copella_author_desc'])) {
+        $desc = sanitize_textarea_field((string) $_POST['copella_author_desc']);
+        update_post_meta($post_id, COPELLA_AUTHOR_META_DESC, $desc);
+    }
+
+    // Save author type and stream-specific settings
+    if (isset($_POST['copella_author_type'])) {
+        $type = strtolower(sanitize_text_field((string) $_POST['copella_author_type']));
+        if ($type !== 'video' && $type !== 'stream') { $type = 'video'; }
+        update_post_meta($post_id, COPELLA_AUTHOR_META_TYPE, $type);
+    }
+    
+    // Save stream-specific fields
+    if (isset($_POST['copella_author_program_id'])) {
+        update_post_meta($post_id, COPELLA_AUTHOR_META_PROGRAM_ID, absint((string) $_POST['copella_author_program_id']));
+    }
+    
+    if (isset($_POST['copella_author_stream_url'])) {
+        $stream_url = sanitize_url((string) $_POST['copella_author_stream_url']);
+        update_post_meta($post_id, COPELLA_AUTHOR_META_STREAM_URL, $stream_url);
+    }
+    
+    if (isset($_POST['copella_author_stream_info'])) {
+        $stream_info = sanitize_textarea_field((string) $_POST['copella_author_stream_info']);
+        update_post_meta($post_id, COPELLA_AUTHOR_META_STREAM_INFO, $stream_info);
+    }
+    
+    // Save live status
+    $is_live = isset($_POST['copella_author_is_live']) && $_POST['copella_author_is_live'] === '1' ? '1' : '0';
+    update_post_meta($post_id, COPELLA_AUTHOR_META_IS_LIVE, $is_live);
+
+    // Save links
+    if (isset($_POST['copella_author_page_id'])) {
+        update_post_meta($post_id, COPELLA_AUTHOR_META_PAGE_ID, absint((string) $_POST['copella_author_page_id']));
+    }
+}
+add_action('save_post_topic_author', 'copella_author_save_meta_boxes');
+

--- a/plugin2/topics-playlists-plugin/includes/search.php
+++ b/plugin2/topics-playlists-plugin/includes/search.php
@@ -1,0 +1,597 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Advanced search shortcode [tp_search]
+ *
+ * Features:
+ * - Tokenization with simple RU/EN stemming and stop-word removal
+ * - Relevance scoring by fields (title/excerpt/content/taxonomies) + phrase bonus + recency bonus
+ * - Manual sorting by score with pagination
+ * - Highlighting query terms in titles and excerpts
+ * - Lightweight UI: search box, filters (post types), sort switch, results grid
+ */
+
+add_action('init', function (): void {
+    add_shortcode('tp_search', 'copella_topics_render_search');
+});
+
+function copella_topics_render_search(array $atts = []): string
+{
+    $a = shortcode_atts(array(
+        'post_types' => 'post,topic,page',
+        'per_page'   => '12',
+        'max_query'  => '120',
+        'sort'       => 'relevance',
+        'placeholder'=> __('Поиск по сайту…', 'copella-topics'),
+        'show_filters'=> 'true',
+        'action'     => '',
+    ), $atts, 'tp_search');
+
+    $allowedPostTypes = array('post', 'page', 'topic', 'topic_playlist');
+    $requestedTypes = array_filter(array_map('trim', explode(',', (string) $a['post_types'])));
+    $postTypes = array_values(array_intersect($allowedPostTypes, $requestedTypes ?: $allowedPostTypes));
+    if (empty($postTypes)) {
+        $postTypes = array('post', 'topic', 'page');
+    }
+
+    $perPage   = max(1, min(40, (int) $a['per_page']));
+    $maxQuery  = max(40, min(300, (int) $a['max_query']));
+    $defaultSort = strtolower((string) $a['sort']) === 'date' ? 'date' : 'relevance';
+    $showFilters = filter_var($a['show_filters'], FILTER_VALIDATE_BOOLEAN);
+
+    $get_s       = isset($_GET['s']) ? (string) $_GET['s'] : '';
+    $queryText   = copella_topics_sanitize_query_text($get_s, $maxQuery);
+    if ($queryText === '' && isset($_GET['q']) && (string) $_GET['q'] !== '') {
+        $queryText = copella_topics_sanitize_query_text((string) $_GET['q'], $maxQuery);
+    }
+
+    $selectedTypes = array();
+    if (isset($_GET['tp_types'])) {
+        if (is_array($_GET['tp_types'])) {
+            $selectedTypes = array_map('sanitize_text_field', (array) $_GET['tp_types']);
+        } else {
+            $selectedTypes = array_filter(array_map('trim', explode(',', (string) $_GET['tp_types'])));
+        }
+    }
+    $activeTypes = array_values(array_intersect($postTypes, $selectedTypes));
+    if (empty($activeTypes)) {
+        $activeTypes = $postTypes;
+    }
+
+    // Sorting is simplified: always by relevance, no UI controls
+    $sort = 'relevance';
+
+    $page = isset($_GET['tp_page']) ? max(1, (int) $_GET['tp_page']) : 1;
+
+    $uid = 'tp_search_' . wp_generate_password(8, false, false);
+
+    $results = array();
+    $totalFound = 0;
+
+    if ($queryText !== '') {
+        $tokens = copella_topics_extract_tokens($queryText);
+
+        $queryArgs = array(
+            'post_type'        => count($activeTypes) === 1 ? $activeTypes[0] : $activeTypes,
+            'post_status'      => 'publish',
+            's'                => $queryText,
+            'posts_per_page'   => 80,
+            'orderby'          => 'date',
+            'order'            => 'DESC',
+            'suppress_filters' => false,
+            'ignore_sticky_posts' => true,
+        );
+
+        $q = new WP_Query($queryArgs);
+        $candidates = array();
+        if ($q->have_posts()) {
+            while ($q->have_posts()) {
+                $q->the_post();
+                $pid = get_the_ID();
+                $scoreInfo = copella_topics_score_post($pid, $tokens, $queryText);
+                if ($scoreInfo['score'] > 0) {
+                    $candidates[] = $scoreInfo;
+                }
+            }
+            wp_reset_postdata();
+        }
+
+        usort($candidates, function ($a, $b) {
+            // Relevance first; if equal, newer first
+            if ($a['score'] === $b['score']) {
+                return $b['date'] - $a['date'];
+            }
+            return $b['score'] <=> $a['score'];
+        });
+
+        $totalFound = count($candidates);
+        $offset = ($page - 1) * $perPage;
+        $pagedItems = array_slice($candidates, $offset, $perPage);
+
+        foreach ($pagedItems as $it) {
+            $results[] = $it;
+        }
+    }
+
+    ob_start();
+    ?>
+    <section id="<?php echo esc_attr($uid); ?>" class="tp-search" aria-label="<?php echo esc_attr__('Расширенный поиск', 'copella-topics'); ?>">
+        <form class="tps-form" role="search" method="get" action="<?php echo esc_url(copella_topics_search_form_action_url((string) $a['action'])); ?>">
+            <div class="tps-bar">
+                <button type="button" class="tps-params" aria-haspopup="dialog" aria-controls="<?php echo esc_attr($uid); ?>_filters" aria-expanded="false" title="<?php echo esc_attr__('Параметры поиска', 'copella-topics'); ?>">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M4 6h16M6 12h12M10 18h4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                    <span class="tps-params-text"><?php echo esc_html__('Фильтр', 'copella-topics'); ?></span>
+                </button>
+                <input type="hidden" name="s" value="<?php echo esc_attr($queryText); ?>" />
+            </div>
+            <input type="hidden" name="tp_page" value="<?php echo (int) $page; ?>" />
+            <?php if ($showFilters): ?>
+            <div class="tps-modal" id="<?php echo esc_attr($uid); ?>_filters" role="dialog" aria-modal="true" hidden>
+                <div class="tps-sheet" role="document">
+                    <div class="tps-sheet-h">
+                        <span><?php echo esc_html__('Параметры', 'copella-topics'); ?></span>
+                        <button type="button" class="tps-close" aria-label="<?php echo esc_attr__('Закрыть', 'copella-topics'); ?>">
+                            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M6 6l12 12M18 6L6 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </button>
+                    </div>
+                    <div class="tps-sheet-b">
+                        <div class="tps-filter-group">
+                            <div class="tps-filter-label"><?php echo esc_html__('Типы', 'copella-topics'); ?></div>
+                            <div class="tps-chips">
+                                <?php foreach ($postTypes as $pt): $checked = in_array($pt, $activeTypes, true); ?>
+                                    <label class="tps-chip">
+                                        <input type="checkbox" name="tp_types[]" value="<?php echo esc_attr($pt); ?>" <?php checked($checked); ?> />
+                                        <span><?php echo esc_html(copella_topics_human_pt($pt)); ?></span>
+                                    </label>
+                                <?php endforeach; ?>
+                            </div>
+                        </div>
+                        
+                    </div>
+                    <div class="tps-sheet-f">
+                        <button type="button" class="tps-reset"><?php echo esc_html__('Сбросить', 'copella-topics'); ?></button>
+                        <button type="button" class="tps-apply"><?php echo esc_html__('Применить', 'copella-topics'); ?></button>
+                    </div>
+                </div>
+            </div>
+            <?php endif; ?>
+        </form>
+
+        <?php if ($queryText === ''): ?>
+            <div class="tps-empty">
+                <div class="tps-search-icon">
+                    <svg width="64" height="64" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <circle cx="11" cy="11" r="8" stroke="currentColor" stroke-width="2"/>
+                        <path d="m21 21-4.35-4.35" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    </svg>
+                </div>
+                <h3 class="tps-empty-title"><?php echo esc_html__('Введите свой запрос', 'copella-topics'); ?></h3>
+                <p class="tps-empty-desc"><?php echo esc_html__('Ищите по заголовкам, описаниям, содержимому и тегам', 'copella-topics'); ?></p>
+            </div>
+        <?php else: ?>
+            <div class="tps-meta">
+                <span class="tps-count"><?php echo esc_html(sprintf(_n('%d результат', '%d результатов', $totalFound, 'copella-topics'), (int) $totalFound)); ?></span>
+                <?php if ($totalFound > 0): ?>
+                    <span class="tps-query">«<?php echo esc_html($queryText); ?>»</span>
+                <?php endif; ?>
+            </div>
+
+            <?php if ($totalFound === 0): ?>
+                <div class="tps-nores" role="status"><?php echo esc_html__('Ничего не найдено. Попробуйте упростить запрос или выбрать другие типы материалов.', 'copella-topics'); ?></div>
+            <?php else: ?>
+                <div class="tps-list" role="list">
+                    <?php foreach ($results as $row): ?>
+                        <?php
+                            $pid = $row['id'];
+                            $pt  = get_post_type($pid);
+                            $titleRaw = get_the_title($pid);
+                            $title = copella_topics_highlight($titleRaw, $row['tokens']);
+                            $thumb = get_the_post_thumbnail_url($pid, 'medium');
+                            $excerptRaw = $row['excerpt'];
+                            $excerptShort = wp_trim_words(wp_strip_all_tags($excerptRaw), 18, '…');
+                            $excerpt = copella_topics_highlight($excerptShort, $row['tokens']);
+                            $url = get_permalink($pid);
+                            $date = mysql2date(get_option('date_format'), get_post_field('post_date', $pid));
+                            $scorePercent = min(100, max(10, (int) round($row['score'] * 100)));
+                            $cat_terms = get_the_terms($pid, 'category');
+                            $cats = array();
+                            if (is_array($cat_terms)) { foreach ($cat_terms as $t) { $cats[] = (string) $t->name; } }
+                            $plBadges = copella_topics_collect_playlist_badges_for_post($pid);
+                            $plTags = isset($plBadges['tags']) ? (array)$plBadges['tags'] : array();
+                            $plGroups = isset($plBadges['groups']) ? (array)$plBadges['groups'] : array();
+                        ?>
+                        <a class="tps-item" role="listitem" href="<?php echo esc_url($url); ?>" title="<?php echo esc_attr(wp_strip_all_tags($titleRaw)); ?>">
+                            <span class="tps-thumb" aria-hidden="true">
+                                <?php if ($thumb): ?><img src="<?php echo esc_url($thumb); ?>" alt="" loading="lazy"/><?php else: ?><span class="tps-fallback"></span><?php endif; ?>
+                            </span>
+                            <span class="tps-body">
+                                <span class="tps-ttl"><?php echo $title; ?></span>
+                                <span class="tps-meta-line"><span class="tps-date"><?php echo esc_html($date); ?></span></span>
+                                <?php if (!empty($cats) || !empty($plTags) || !empty($plGroups)): ?>
+                                    <span class="tps-tax">
+                                        <?php foreach ($cats as $nm): ?>
+                                            <span class="tps-tax-chip tps-tax-cat"><?php echo copella_topics_highlight($nm, $row['tokens']); ?></span>
+                                        <?php endforeach; ?>
+                                        <?php foreach ($plGroups as $nm): ?>
+                                            <span class="tps-tax-chip tps-tax-group"><?php echo copella_topics_highlight($nm, $row['tokens']); ?></span>
+                                        <?php endforeach; ?>
+                                        <?php foreach ($plTags as $nm): ?>
+                                            <span class="tps-tax-chip tps-tax-tag"><?php echo copella_topics_highlight($nm, $row['tokens']); ?></span>
+                                        <?php endforeach; ?>
+                                    </span>
+                                <?php endif; ?>
+                                <?php if ($excerpt): ?><span class="tps-excerpt"><?php echo $excerpt; ?></span><?php endif; ?>
+                            </span>
+                        </a>
+                    <?php endforeach; ?>
+                </div>
+
+                <?php
+                $maxPages = max(1, (int) ceil($totalFound / $perPage));
+                if ($maxPages > 1):
+                    $baseUrl = remove_query_arg('tp_page');
+                ?>
+                    <nav class="tps-pager" aria-label="<?php echo esc_attr__('Пагинация результатов', 'copella-topics'); ?>">
+                        <?php for ($i = 1; $i <= $maxPages; $i++):
+                            $url = esc_url(add_query_arg('tp_page', (string) $i, $baseUrl));
+                            $isActive = $i === $page;
+                        ?>
+                            <a class="tps-pg <?php echo $isActive ? 'is-active' : ''; ?>" href="<?php echo $url; ?>"><?php echo (int) $i; ?></a>
+                        <?php endfor; ?>
+                    </nav>
+                <?php endif; ?>
+            <?php endif; ?>
+        <?php endif; ?>
+
+        <style>
+        .tp-search{--tps-gap:12px;--tps-radius:14px;--tps-card-bg:#171717;--tps-muted:#a1a1a1;color:#fff;font-family:'Gilroy-SemiBold','Gilroy-Bold',system-ui,-apple-system,'Segoe UI',Roboto,Arial,sans-serif;padding-left:16px;padding-right:16px}
+        .tp-search .tps-bar{display:flex;gap:8px;align-items:center;margin:0 0 10px 0}
+        .tp-search .tps-params{display:inline-flex;align-items:center;justify-content:center;gap:8px;height:38px;padding:0 16px;border-radius:10px;border:1px solid rgba(255,255,255,.08);background:#0f0f0f;color:#fff;font-family:'Gilroy-SemiBold','Gilroy-Bold',system-ui,-apple-system,'Segoe UI',Roboto,Arial,sans-serif;font-size:14px;font-weight:600}
+        .tp-search .tps-params-text{display:none}
+        @media (min-width: 480px){.tp-search .tps-params-text{display:inline}}
+        .tp-search .tps-bar input[type=search]{flex:1;min-width:0;padding:10px 12px;border-radius:12px;border:1px solid rgba(255,255,255,.08);background:#0f0f0f;color:#fff;font-family:'Gilroy-SemiBold','Gilroy-Bold',system-ui,-apple-system,'Segoe UI',Roboto,Arial,sans-serif;font-size:15px}
+        .tp-search .tps-bar input[type=search]::placeholder{color:rgba(255,255,255,.55)}
+        .tp-search .tps-bar .tps-btn{display:inline-flex;align-items:center;justify-content:center;height:38px;width:44px;border-radius:10px;border:1px solid rgba(255,255,255,.08);background:#0f0f0f;color:#fff}
+        .tp-search .tps-filters{display:none}
+        .tp-search .tps-filter-group{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+        .tp-search .tps-filter-label{opacity:.8}
+        .tp-search .tps-chip{display:inline-flex;align-items:center;gap:6px;background:rgba(255,255,255,.06);border:0;border-radius:12px;padding:6px 10px;color:#fff}
+        .tp-search .tps-chip input{accent-color:#ff653a}
+        .tp-search .tps-meta{display:flex;gap:8px;align-items:center;margin:6px 0 10px 0}
+        .tp-search .tps-count{font-weight:600}
+        .tp-search .tps-query{opacity:.7}
+        .tp-search .tps-list{display:flex;flex-direction:column;gap:10px}
+        .tp-search .tps-item{display:flex;gap:12px;align-items:center;color:inherit;text-decoration:none;border-radius:12px;padding:8px 10px;background:var(--tps-card-bg);border:1px solid rgba(255,255,255,.06)}
+        .tp-search .tps-item:hover{background:rgba(255,255,255,.04)}
+        .tp-search .tps-thumb{width:76px;flex:0 0 auto;aspect-ratio:16/9;border-radius:10px;background:#0f0f0f;overflow:hidden;position:relative}
+        .tp-search .tps-thumb img{width:100%;height:100%;object-fit:cover;display:block}
+        @supports not (aspect-ratio: 1 / 1){.tp-search .tps-thumb{padding-top:56%}.tp-search .tps-thumb img{position:absolute;inset:0}}
+        .tp-search .tps-fallback{display:block;width:100%;height:100%;background:linear-gradient(135deg,#222,#111)}
+        .tp-search .tps-body{display:flex;flex-direction:column;gap:4px;min-width:0}
+        .tp-search .tps-ttl{display:block;font-weight:700;font-family:'Gilroy-Bold','Gilroy-SemiBold',system-ui,-apple-system,'Segoe UI',Roboto,Arial,sans-serif;font-size:15px;line-height:1.3;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+        .tp-search .tps-meta-line{display:flex;gap:8px;align-items:center;opacity:.7;font-size:12px}
+        .tp-search .tps-tax{display:flex;gap:6px;flex-wrap:wrap;margin-top:2px}
+        .tp-search .tps-tax-chip{display:inline-flex;align-items:center;gap:6px;padding:3px 8px;border-radius:999px;background:rgba(255,255,255,.06);color:#fff;font-size:12px}
+        .tp-search .tps-tax-cat{border:1px solid rgba(255,255,255,.1)}
+        .tp-search .tps-tax-group{border:1px solid rgba(255,255,255,.1);background:rgba(255,255,255,.08)}
+        .tp-search .tps-tax-tag{border:1px dashed rgba(255,255,255,.15)}
+        .tp-search .tps-excerpt{display:block;margin-top:0;color:#e6e6e6;opacity:.85;font-size:12.5px;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
+        .tp-search mark{background:#ff653a;color:#111;padding:0 2px;border-radius:3px}
+        .tp-search .tps-pager{display:flex;gap:8px;justify-content:center;margin-top:14px}
+        .tp-search .tps-pg{padding:6px 10px;background:#0f0f0f;border:1px solid rgba(255,255,255,.08);border-radius:10px;color:#fff;text-decoration:none}
+        .tp-search .tps-pg.is-active{background:#fff;color:#111;border-color:#fff}
+        .tp-search .tps-empty{display:flex;flex-direction:column;align-items:center;justify-content:center;padding:60px 20px;text-align:center;opacity:.9;font-family:'Gilroy-SemiBold','Gilroy-Bold',system-ui,-apple-system,'Segoe UI',Roboto,Arial,sans-serif}
+        .tp-search .tps-search-icon{display:flex;align-items:center;justify-content:center;width:80px;height:80px;border-radius:50%;background:rgba(255,255,255,.06);border:2px solid rgba(255,255,255,.1);margin-bottom:24px;color:rgba(255,255,255,.6);animation:tps-pulse 2s ease-in-out infinite}
+        .tp-search .tps-search-icon svg{display:block}
+        .tp-search .tps-search-icon svg circle{stroke-dasharray:60;stroke-dashoffset:60;animation:tps-scan 2.5s ease-in-out infinite}
+        .tp-search .tps-search-icon svg path{animation:tps-bob 3s ease-in-out infinite}
+        .tp-search .tps-empty-title{margin:0 0 12px 0;font-size:24px;font-weight:700;color:#fff;font-family:'Gilroy-Bold','Gilroy-SemiBold',system-ui,-apple-system,'Segoe UI',Roboto,Arial,sans-serif}
+        .tp-search .tps-empty-desc{margin:0;font-size:16px;color:rgba(255,255,255,.7);line-height:1.5;max-width:400px}
+        @keyframes tps-pulse{0%,100%{transform:scale(1);opacity:.6}50%{transform:scale(1.05);opacity:.85}}
+        @keyframes tps-scan{0%{stroke-dashoffset:60;opacity:.7}50%{stroke-dashoffset:30;opacity:1}100%{stroke-dashoffset:0;opacity:.7}}
+        @keyframes tps-bob{0%,100%{transform:translateY(0)}50%{transform:translateY(-2px)}}
+        @media (max-width: 640px){.tp-search{padding-left:12px;padding-right:12px}}
+        @media (max-width: 1024px) and (min-width: 641px){.tp-search{padding-left:16px;padding-right:16px}}
+
+        /* Modal sheet for filters */
+        .tp-search .tps-modal[hidden]{display:none}
+        .tp-search .tps-modal{position:fixed;inset:0;z-index:9999;background:rgba(0,0,0,.5);display:grid;place-items:end center;padding:16px}
+        .tp-search .tps-sheet{width:min(680px,100%);background:#0f0f0f;border:1px solid rgba(255,255,255,.1);border-radius:16px;overflow:hidden;color:#fff}
+        .tp-search .tps-sheet-h{display:flex;align-items:center;justify-content:space-between;padding:12px 14px;border-bottom:1px solid rgba(255,255,255,.08);font-weight:700}
+        .tp-search .tps-close{background:transparent;border:0;color:#fff;width:34px;height:34px;border-radius:10px}
+        .tp-search .tps-sheet-b{padding:12px 14px;display:flex;flex-direction:column;gap:14px}
+        .tp-search .tps-chips{display:flex;gap:8px;flex-wrap:wrap}
+        .tp-search .tps-segment{display:inline-flex;background:rgba(255,255,255,.06);border-radius:12px;padding:4px}
+        .tp-search .tps-seg{display:inline-flex;align-items:center;gap:6px;padding:6px 10px;border-radius:10px;color:#fff}
+        .tp-search .tps-seg input{display:none}
+        .tp-search .tps-seg input:checked + span{background:#fff;color:#111;border-radius:8px;padding:4px 8px}
+        .tp-search .tps-sheet-f{display:flex;gap:8px;justify-content:flex-end;padding:12px 14px;border-top:1px solid rgba(255,255,255,.08)}
+        .tp-search .tps-reset{background:transparent;border:1px solid rgba(255,255,255,.12);border-radius:10px;color:#fff;padding:8px 12px}
+        .tp-search .tps-apply{background:#fff;border:0;border-radius:10px;color:#111;padding:8px 12px}
+        </style>
+        <script>
+        (function(){
+          var root=document.getElementById('<?php echo esc_js($uid); ?>');
+          if(!root) return;
+          var form=root.querySelector('.tps-form');
+          if(!form) return;
+          var modal=root.querySelector('#<?php echo esc_js($uid); ?>_filters');
+          var btnParams=root.querySelector('.tps-params');
+          var btnClose=modal ? modal.querySelector('.tps-close') : null;
+          var btnApply=modal ? modal.querySelector('.tps-apply') : null;
+          var btnReset=modal ? modal.querySelector('.tps-reset') : null;
+
+          function openModal(){ if(!modal) return; modal.hidden=false; if(btnParams){ btnParams.setAttribute('aria-expanded','true'); } }
+          function closeModal(){ if(!modal) return; modal.hidden=true; if(btnParams){ btnParams.setAttribute('aria-expanded','false'); } }
+          if(btnParams){ btnParams.addEventListener('click', openModal); }
+          if(btnClose){ btnClose.addEventListener('click', closeModal); }
+          if(modal){ modal.addEventListener('click', function(e){ if(e.target===modal){ closeModal(); } }); }
+
+          if(btnApply){ btnApply.addEventListener('click', function(){
+            var pageInput=form.querySelector('input[name="tp_page"]');
+            if(pageInput){ pageInput.value='1'; }
+            form.submit();
+            closeModal();
+          }); }
+          if(btnReset){ btnReset.addEventListener('click', function(){
+            var checks=form.querySelectorAll('input[name="tp_types[]"]');
+            checks.forEach(function(c){ c.checked=false; });
+          }); }
+        })();
+        </script>
+    </section>
+    <?php
+    return ob_get_clean();
+}
+
+function copella_topics_sanitize_query_text(string $q, int $maxLen = 120): string
+{
+    $q = trim((string) wp_strip_all_tags($q));
+    if ($q === '') { return ''; }
+    if (function_exists('mb_substr')) {
+        $q = mb_substr($q, 0, $maxLen, 'UTF-8');
+    } else {
+        $q = substr($q, 0, $maxLen);
+    }
+    return $q;
+}
+
+function copella_topics_extract_tokens(string $text): array
+{
+    $l = function_exists('mb_strtolower') ? mb_strtolower($text, 'UTF-8') : strtolower($text);
+    $raw = preg_split('~[^\p{L}\p{N}\-]+~u', $l) ?: array();
+    $stop = array('и','в','на','по','для','о','у','к','с','из','а','но','как','the','and','or','to','of','in','on','for','a','an');
+    $tokens = array();
+    foreach ($raw as $w) {
+        $w = trim($w);
+        if ($w === '' || in_array($w, $stop, true)) { continue; }
+        if (function_exists('mb_strlen') ? (mb_strlen($w, 'UTF-8') < 2) : (strlen($w) < 2)) { continue; }
+        $tokens[] = copella_topics_simple_stem($w);
+    }
+    $tokens = array_values(array_unique($tokens));
+    return $tokens;
+}
+
+function copella_topics_simple_stem(string $w): string
+{
+    if (preg_match('~[а-яё]~u', $w)) {
+        return copella_topics_simple_stem_ru($w);
+    }
+    return copella_topics_simple_stem_en($w);
+}
+
+function copella_topics_simple_stem_ru(string $w): string
+{
+    $w = function_exists('mb_strtolower') ? mb_strtolower($w, 'UTF-8') : strtolower($w);
+    $endings = array('иями','ями','иях','ях','ация','ации','ацию','аций','ами','ями','его','ого','ему','ому','ее','ие','ые','ое','ией','ией','ий','ый','ой','ем','ом','ам','ям','ах','ях','ию','ью','ия','ья','ии','ьи','иям','ьям','иях','ьях','ая','яя','ою','ею','ую');
+    foreach ($endings as $e) {
+        $len = function_exists('mb_strlen') ? mb_strlen($e, 'UTF-8') : strlen($e);
+        $tail = function_exists('mb_substr') ? mb_substr($w, -$len, null, 'UTF-8') : substr($w, -$len);
+        if ($tail === $e && ((function_exists('mb_strlen') ? mb_strlen($w, 'UTF-8') : strlen($w)) > $len + 1)) {
+            return function_exists('mb_substr') ? mb_substr($w, 0, (function_exists('mb_strlen') ? mb_strlen($w, 'UTF-8') : strlen($w)) - $len, 'UTF-8') : substr($w, 0, strlen($w) - $len);
+        }
+    }
+    return $w;
+}
+
+function copella_topics_simple_stem_en(string $w): string
+{
+    $w = strtolower($w);
+    foreach (array('ing','edly','edly','ness','ment','tion','sion','able','ible','ally','ies','ied','ed','es','s') as $e) {
+        if (substr($w, -strlen($e)) === $e && strlen($w) > strlen($e) + 1) {
+            return substr($w, 0, -strlen($e));
+        }
+    }
+    return $w;
+}
+
+function copella_topics_human_pt(string $pt): string
+{
+    switch ($pt) {
+        case 'topic': return __('Тема', 'copella-topics');
+        case 'topic_playlist': return __('Плейлист', 'copella-topics');
+        case 'page': return __('Страница', 'copella-topics');
+        default: return __('Публикация', 'copella-topics');
+    }
+}
+
+function copella_topics_score_post(int $postId, array $tokens, string $queryText): array
+{
+    $title = get_the_title($postId);
+    $excerpt = get_the_excerpt($postId);
+    if ($excerpt === '') {
+        $excerpt = wp_trim_words(strip_shortcodes(strip_tags((string) get_post_field('post_content', $postId))), 40, '…');
+    }
+    $content = (string) get_post_field('post_content', $postId);
+    $contentStripped = wp_strip_all_tags($content);
+    $pt = get_post_type($postId) ?: 'post';
+
+    $l = function($s){ return function_exists('mb_strtolower') ? mb_strtolower((string) $s, 'UTF-8') : strtolower((string) $s); };
+    $titleL = $l($title);
+    $excerptL = $l($excerpt);
+    $contentL = $l($contentStripped);
+
+    $phraseBonus = 0;
+    $qtL = $l($queryText);
+    if ($qtL !== '' && (strpos($titleL, $qtL) !== false)) { $phraseBonus += 6; }
+    if ($qtL !== '' && (strpos($excerptL, $qtL) !== false)) { $phraseBonus += 2; }
+
+    $titleHits = copella_topics_count_hits($titleL, $tokens);
+    $excerptHits = copella_topics_count_hits($excerptL, $tokens);
+    $contentHits = copella_topics_count_hits($contentL, $tokens);
+
+    $taxHits = 0;
+    $terms = array();
+    $taxes = array('category','post_tag');
+    foreach ($taxes as $tx) {
+        $t = get_the_terms($postId, $tx);
+        if (is_array($t)) { $terms = array_merge($terms, $t); }
+    }
+    if (!empty($terms)) {
+        $names = array();
+        foreach ($terms as $term) { $names[] = (string) $term->name; }
+        $namesL = $l(implode(' ', $names));
+        $taxHits = copella_topics_count_hits($namesL, $tokens);
+    }
+
+    $dateU = get_post_time('U', true, $postId);
+    $nowU = current_time('timestamp');
+    $ageDays = max(0, ($nowU - (int) $dateU) / 86400);
+    $recency = max(0.0, 1.0 - min(730.0, $ageDays) / 730.0);
+
+    $ptWeight = 1.0;
+    if ($pt === 'topic') { $ptWeight = 1.15; }
+    elseif ($pt === 'page') { $ptWeight = 0.95; }
+    elseif ($pt === 'topic_playlist') { $ptWeight = 0.9; }
+
+    $score = 0.0;
+    $score += $titleHits * 4.0;
+    $score += $excerptHits * 2.5;
+    $score += $contentHits * 1.0;
+    $score += $taxHits * 3.0;
+    $score += $phraseBonus;
+    $score += $recency * 2.0;
+    $score *= $ptWeight;
+
+    $scoreNorm = 1.0 - exp(-$score / 6.0);
+
+    $badges = array();
+    if ($titleHits > 0) { $badges[] = __('в заголовке', 'copella-topics'); }
+    if ($excerptHits > 0) { $badges[] = __('в описании', 'copella-topics'); }
+    if ($taxHits > 0) { $badges[] = __('в тегах/категориях', 'copella-topics'); }
+    if ($phraseBonus > 0) { $badges[] = __('фразовое совпадение', 'copella-topics'); }
+
+    return array(
+        'id'      => $postId,
+        'score'   => $scoreNorm,
+        'date'    => (int) $dateU,
+        'badges'  => $badges,
+        'tokens'  => $tokens,
+        'excerpt' => $excerpt,
+    );
+}
+
+function copella_topics_count_hits(string $haystackL, array $tokens): int
+{
+    $hits = 0;
+    foreach ($tokens as $t) {
+        $pattern = '~\b' . preg_quote($t, '~') . '(?:[\p{L}\p{N}]*)\b~u';
+        if (preg_match_all($pattern, $haystackL, $m)) { $hits += (int) count($m[0]); }
+    }
+    return $hits;
+}
+
+function copella_topics_highlight(string $text, array $tokens): string
+{
+    if ($text === '' || empty($tokens)) { return esc_html($text); }
+    $clean = wp_strip_all_tags($text);
+    $safe = esc_html($clean);
+    foreach ($tokens as $t) {
+        $pattern = '~(\b)(' . preg_quote($t, '~') . '([\p{L}\p{N}]*)\b)~iu';
+        $safe = preg_replace($pattern, '$1<mark>$2</mark>', (string) $safe);
+    }
+    return $safe;
+}
+
+function copella_topics_search_form_action_url(string $override = ''): string
+{
+    // If override action is given, use it
+    if (!empty($override)) {
+        return $override;
+    }
+    // Prefer the current URL (including path) without pagination to keep the user on the same page
+    $base = remove_query_arg(array('tp_page'));
+    // If action becomes empty (e.g. in some builders), fallback to home_url
+    $current = (string) $base;
+    if ($current === '' || $current === home_url() || $current === site_url()) {
+        // Try to use the current request URI to preserve the page where shortcode lives
+        $req = isset($_SERVER['REQUEST_URI']) ? (string) $_SERVER['REQUEST_URI'] : '';
+        if ($req !== '') {
+            $action = home_url($req);
+        } else {
+            $action = home_url('/');
+        }
+    } else {
+        $action = $current;
+    }
+    return $action;
+}
+
+/**
+ * Collect playlist badges for a given post:
+ * - tags from playlist items (tag=...)
+ * - group titles from playlists (# Group)
+ */
+function copella_topics_collect_playlist_badges_for_post(int $postId): array
+{
+    $tags = array();
+    $groups = array();
+
+    $q = new WP_Query(array(
+        'post_type' => 'topic_playlist',
+        'post_status' => array('publish','private','draft'),
+        'posts_per_page' => 300,
+        'no_found_rows' => true,
+        'fields' => 'ids',
+    ));
+    if ($q->have_posts()) {
+        foreach ($q->posts as $pid) {
+            $videos_raw = (string) get_post_meta((int)$pid, COPELLA_PLAYLIST_META_ITEMS, true);
+            if ($videos_raw === '') { continue; }
+            $rawLines = preg_split("/\r\n|\r|\n/", $videos_raw);
+            $currentGroup = '';
+            if (is_array($rawLines)) {
+                foreach ($rawLines as $rawLine) {
+                    $line = trim((string) $rawLine);
+                    if ($line === '') { continue; }
+                    if (preg_match('~^#+\s*(.+)$~u', $line, $m)) {
+                        $currentGroup = trim((string) $m[1]);
+                        continue;
+                    }
+                    $parts = array_map('trim', explode('|', $line));
+                    $idOrUrl = array_shift($parts);
+                    $matchedPostId = 0;
+                    if (ctype_digit($idOrUrl)) { $matchedPostId = (int) $idOrUrl; }
+                    else { $matchedPostId = url_to_postid($idOrUrl); }
+                    if ($matchedPostId !== $postId) { continue; }
+                    $metaTag = '';
+                    foreach ($parts as $p) {
+                        if (stripos($p, 'tag=') === 0) { $metaTag = trim(substr($p, 4)); }
+                    }
+                    if ($metaTag !== '') { $tags[] = $metaTag; }
+                    if ($currentGroup !== '') { $groups[] = $currentGroup; }
+                }
+            }
+        }
+    }
+    wp_reset_postdata();
+    return array(
+        'tags' => array_values(array_unique(array_filter($tags))),
+        'groups' => array_values(array_unique(array_filter($groups))),
+    );
+}
+
+

--- a/plugin2/topics-playlists-plugin/includes/shortcodes-authors.php
+++ b/plugin2/topics-playlists-plugin/includes/shortcodes-authors.php
@@ -1,0 +1,658 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Shortcode: [video_authors] - Render video authors grid
+ */
+function copella_topics_render_video_authors(array $atts = []): string
+{
+    $a = shortcode_atts(array(
+        'title' => __('Авторы видео', 'copella-topics'),
+        'posts_per_page' => '50',
+        'columns' => '3',
+        'gap' => '24',
+        'cover_ratio' => '16/9',
+        'layout' => 'grid',
+    ), $atts, 'video_authors');
+
+    $perPage = max(1, (int)$a['posts_per_page']);
+    $columns = max(1, min(4, (int)$a['columns']));
+    $gap = max(8, (int)$a['gap']);
+    $coverRatio = preg_replace('~[^0-9/\.]+~', '', (string) $a['cover_ratio']);
+    $layout = strtolower(trim((string)$a['layout'])) === 'tabs' ? 'tabs' : 'grid';
+
+    $q = new WP_Query(array(
+        'post_type' => 'topic_author',
+        'post_status' => 'publish',
+        'posts_per_page' => $perPage,
+        'orderby' => 'menu_order title',
+        'order' => 'ASC',
+        'meta_query' => array(
+            'relation' => 'OR',
+            array(
+                'key' => COPELLA_AUTHOR_META_TYPE,
+                'compare' => 'NOT EXISTS',
+            ),
+            array(
+                'key' => COPELLA_AUTHOR_META_TYPE,
+                'value' => 'stream',
+                'compare' => '!=',
+            )
+        ),
+        'no_found_rows' => true,
+    ));
+
+    $uid = 'pl_vauthors_' . wp_generate_password(8, false, false);
+    ob_start();
+    ?>
+    <section id="<?php echo esc_attr($uid); ?>" class="copella-authors<?php echo $layout === 'tabs' ? ' is-tabs' : ''; ?>" style="<?php echo esc_attr(sprintf('--au-cols:%d;--au-gap:%dpx;--au-cover-ratio:%s;', $columns, $gap, $coverRatio ?: '16/9')); ?>">
+        <?php if (!empty($a['title'])): ?><h3 class="au-title"><?php echo esc_html((string)$a['title']); ?></h3><?php endif; ?>
+        
+        <?php if ($layout === 'tabs' && $q->have_posts()): ?>
+            <div class="au-tabsbar" aria-label="<?php echo esc_attr__('Авторы', 'copella-topics'); ?>">
+                <button class="au-tabs-nav au-prev" type="button" aria-label="<?php echo esc_attr__('Назад', 'copella-topics'); ?>" title="<?php echo esc_attr__('Назад', 'copella-topics'); ?>">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M15 5L8 12L15 19" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                </button>
+                <div class="au-tabs-viewport">
+                    <div class="au-tabs" role="tablist">
+                        <button type="button" class="au-tab is-active" role="tab" aria-selected="true" aria-controls="<?php echo esc_attr($uid . '_panel_all'); ?>" id="<?php echo esc_attr($uid . '_tab_all'); ?>" data-au-index="all">
+                            <?php echo esc_html__('Все', 'copella-topics'); ?>
+                        </button>
+                        <?php
+                        $tabIndex = 0;
+                        while ($q->have_posts()): $q->the_post();
+                            $authorName = get_the_title();
+                        ?>
+                            <button type="button" class="au-tab" role="tab" aria-selected="false" aria-controls="<?php echo esc_attr($uid . '_panel_' . $tabIndex); ?>" id="<?php echo esc_attr($uid . '_tab_' . $tabIndex); ?>" data-au-index="<?php echo (int) $tabIndex; ?>">
+                                <?php echo esc_html($authorName); ?>
+                            </button>
+                        <?php
+                            $tabIndex++;
+                        endwhile;
+                        wp_reset_postdata();
+                        ?>
+                    </div>
+                </div>
+                <button class="au-tabs-nav au-next" type="button" aria-label="<?php echo esc_attr__('Вперед', 'copella-topics'); ?>" title="<?php echo esc_attr__('Вперед', 'copella-topics'); ?>">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M9 5L16 12L9 19" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                </button>
+            </div>
+
+            <div class="au-panels">
+                <div class="au-panel is-active" role="tabpanel" id="<?php echo esc_attr($uid . '_panel_all'); ?>" aria-labelledby="<?php echo esc_attr($uid . '_tab_all'); ?>" data-au-index="all">
+                    <div class="au-grid">
+                        <?php
+                        $q->rewind_posts();
+                        while ($q->have_posts()): $q->the_post();
+                            $aid = get_the_ID();
+                            $name = get_the_title();
+                            $cover = get_the_post_thumbnail_url($aid, 'medium_large');
+                            $desc = copella_topics_get_author_desc($aid);
+                            $pl_ids = copella_topics_get_author_playlist_ids($aid);
+                        ?>
+                            <article class="au-card is-collapsed">
+                                <div class="au-header" role="button" tabindex="0" aria-expanded="false">
+                                    <h4 class="au-name"><?php echo esc_html($name); ?></h4>
+                                    <button class="au-arrow" type="button" aria-label="<?php echo esc_attr__('Развернуть', 'copella-topics'); ?>"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                                </div>
+                                <div class="au-cover" aria-hidden="true">
+                                    <?php if ($cover): ?><img src="<?php echo esc_url($cover); ?>" alt="" loading="lazy"/><?php endif; ?>
+                                </div>
+                                <div class="au-body">
+                                    <?php if (!empty($desc)): ?><p class="au-desc"><?php echo esc_html($desc); ?></p><?php endif; ?>
+                                    <?php echo copella_topics_render_author_social_networks($aid); ?>
+                                    <?php echo copella_topics_render_author_playlists($pl_ids); ?>
+                                </div>
+                            </article>
+                        <?php endwhile; wp_reset_postdata(); ?>
+                    </div>
+                </div>
+                <?php
+                $panelIndex = 0;
+                $q->rewind_posts();
+                while ($q->have_posts()): $q->the_post();
+                    $aid = get_the_ID();
+                    $name = get_the_title();
+                    $cover = get_the_post_thumbnail_url($aid, 'medium_large');
+                    $desc = copella_topics_get_author_desc($aid);
+                    $pl_ids = copella_topics_get_author_playlist_ids($aid);
+                ?>
+                    <div class="au-panel" role="tabpanel" id="<?php echo esc_attr($uid . '_panel_' . $panelIndex); ?>" aria-labelledby="<?php echo esc_attr($uid . '_tab_' . $panelIndex); ?>" data-au-index="<?php echo (int) $panelIndex; ?>">
+                        <div class="au-grid au-grid--individual-tab">
+                            <article class="au-card au-card--full-width au-card--no-cover">
+                                <div class="au-header">
+                                    <h4 class="au-name">
+                                        <?php if ($cover): ?>
+                                            <span class="au-author-icon">
+                                                <img src="<?php echo esc_url($cover); ?>" alt="" loading="lazy"/>
+                                            </span>
+                                        <?php else: ?>
+                                            <span class="au-author-icon"><?php echo esc_html(mb_substr($name, 0, 1)); ?></span>
+                                        <?php endif; ?>
+                                        <?php echo esc_html($name); ?>
+                                    </h4>
+                                </div>
+                                <div class="au-body">
+                                    <?php if (!empty($desc)): ?><p class="au-desc"><?php echo esc_html($desc); ?></p><?php endif; ?>
+                                    <?php echo copella_topics_render_author_social_networks($aid); ?>
+                                    <?php echo copella_topics_render_author_playlists($pl_ids, true, true); ?>
+                                </div>
+                            </article>
+                        </div>
+                    </div>
+                <?php
+                    $panelIndex++;
+                endwhile;
+                wp_reset_postdata();
+                ?>
+            </div>
+        <?php else: ?>
+            <div class="au-grid">
+                <?php if ($q->have_posts()): while ($q->have_posts()): $q->the_post();
+                    $aid = get_the_ID();
+                    $name = get_the_title();
+                    $cover = get_the_post_thumbnail_url($aid, 'medium_large');
+                    $desc = copella_topics_get_author_desc($aid);
+                    $pl_ids = copella_topics_get_author_playlist_ids($aid);
+                ?>
+                <article class="au-card is-collapsed">
+                    <div class="au-header" role="button" tabindex="0" aria-expanded="false">
+                        <h4 class="au-name"><?php echo esc_html($name); ?></h4>
+                        <button class="au-arrow" type="button" aria-label="<?php echo esc_attr__('Развернуть', 'copella-topics'); ?>"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                    </div>
+                    <div class="au-cover" aria-hidden="true">
+                        <?php if ($cover): ?><img src="<?php echo esc_url($cover); ?>" alt="" loading="lazy"/><?php endif; ?>
+                    </div>
+                    <div class="au-body">
+                        <?php if (!empty($desc)): ?><p class="au-desc"><?php echo esc_html($desc); ?></p><?php endif; ?>
+                        <?php echo copella_topics_render_author_social_networks($aid); ?>
+                        <?php echo copella_topics_render_author_playlists($pl_ids); ?>
+                    </div>
+                </article>
+                <?php endwhile; wp_reset_postdata(); else: ?>
+                    <div class="au-empty"><?php echo esc_html__('Авторы не найдены.', 'copella-topics'); ?></div>
+                <?php endif; ?>
+            </div>
+        <?php endif; ?>
+    </section>
+    
+    <script>
+    // Initialize this specific author container when DOM is ready
+    (function() {
+        if (typeof window.CopellaAuthors !== 'undefined') {
+            var container = document.getElementById('<?php echo esc_js($uid); ?>');
+            if (container) {
+                window.CopellaAuthors.init(container);
+            }
+        }
+    })();
+    </script>
+    <?php
+    return ob_get_clean();
+}
+
+/**
+ * Shortcode: [stream_authors] - Render stream authors grid
+ */
+function copella_topics_render_stream_authors(array $atts = []): string
+{
+    $a = shortcode_atts(array(
+        'title' => __('Авторы стримов', 'copella-topics'),
+        'posts_per_page' => '50',
+        'columns' => '3',
+        'gap' => '24',
+        'cover_ratio' => '16/9',
+        'layout' => 'grid',
+    ), $atts, 'stream_authors');
+
+    $perPage = max(1, (int)$a['posts_per_page']);
+    $columns = max(1, min(4, (int)$a['columns']));
+    $gap = max(8, (int)$a['gap']);
+    $coverRatio = preg_replace('~[^0-9/\.]+~', '', (string) $a['cover_ratio']);
+    $layout = strtolower(trim((string)$a['layout'])) === 'tabs' ? 'tabs' : 'grid';
+
+    $q = new WP_Query(array(
+        'post_type' => 'topic_author',
+        'post_status' => 'publish',
+        'posts_per_page' => $perPage,
+        'orderby' => 'menu_order title',
+        'order' => 'ASC',
+        'meta_key' => COPELLA_AUTHOR_META_TYPE,
+        'meta_value' => 'stream',
+        'no_found_rows' => true,
+    ));
+
+    $uid = 'pl_sauthors_' . wp_generate_password(8, false, false);
+    ob_start();
+    ?>
+    <section id="<?php echo esc_attr($uid); ?>" class="copella-authors<?php echo $layout === 'tabs' ? ' is-tabs' : ''; ?>" style="<?php echo esc_attr(sprintf('--au-cols:%d;--au-gap:%dpx;--au-cover-ratio:%s;', $columns, $gap, $coverRatio ?: '16/9')); ?>">
+        <?php if (!empty($a['title'])): ?><h3 class="au-title"><?php echo esc_html((string)$a['title']); ?></h3><?php endif; ?>
+        
+        <?php if ($layout === 'tabs' && $q->have_posts()): ?>
+            <div class="au-tabsbar" aria-label="<?php echo esc_attr__('Авторы', 'copella-topics'); ?>">
+                <button class="au-tabs-nav au-prev" type="button" aria-label="<?php echo esc_attr__('Назад', 'copella-topics'); ?>" title="<?php echo esc_attr__('Назад', 'copella-topics'); ?>">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M15 5L8 12L15 19" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                </button>
+                <div class="au-tabs-viewport">
+                    <div class="au-tabs" role="tablist">
+                        <button type="button" class="au-tab is-active" role="tab" aria-selected="true" aria-controls="<?php echo esc_attr($uid . '_panel_all'); ?>" id="<?php echo esc_attr($uid . '_tab_all'); ?>" data-au-index="all">
+                            <?php echo esc_html__('Все', 'copella-topics'); ?>
+                        </button>
+                        <?php
+                        $tabIndex = 0;
+                        while ($q->have_posts()): $q->the_post();
+                            $authorName = get_the_title();
+                        ?>
+                            <button type="button" class="au-tab" role="tab" aria-selected="false" aria-controls="<?php echo esc_attr($uid . '_panel_' . $tabIndex); ?>" id="<?php echo esc_attr($uid . '_tab_' . $tabIndex); ?>" data-au-index="<?php echo (int) $tabIndex; ?>">
+                                <?php echo esc_html($authorName); ?>
+                            </button>
+                        <?php
+                            $tabIndex++;
+                        endwhile;
+                        wp_reset_postdata();
+                        ?>
+                    </div>
+                </div>
+                <button class="au-tabs-nav au-next" type="button" aria-label="<?php echo esc_attr__('Вперед', 'copella-topics'); ?>" title="<?php echo esc_attr__('Вперед', 'copella-topics'); ?>">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M9 5L16 12L9 19" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                </button>
+            </div>
+
+            <div class="au-panels">
+                <div class="au-panel is-active" role="tabpanel" id="<?php echo esc_attr($uid . '_panel_all'); ?>" aria-labelledby="<?php echo esc_attr($uid . '_tab_all'); ?>" data-au-index="all">
+                    <div class="au-grid">
+                        <?php
+                        $q->rewind_posts();
+                        while ($q->have_posts()): $q->the_post();
+                            $aid = get_the_ID();
+                            $name = get_the_title();
+                            $cover = get_the_post_thumbnail_url($aid, 'medium_large');
+                            $streamUrl = (string) get_post_meta($aid, COPELLA_AUTHOR_META_STREAM_URL, true);
+                            $isLive = (string) get_post_meta($aid, COPELLA_AUTHOR_META_IS_LIVE, true) === '1';
+                            $desc = copella_topics_get_author_desc($aid);
+                            $link = $streamUrl ?: get_permalink($aid);
+                            $programId = (int) get_post_meta($aid, COPELLA_AUTHOR_META_PROGRAM_ID, true);
+                        ?>
+                        <article class="au-card is-stream is-collapsed">
+                            <div class="au-header" role="button" tabindex="0" aria-expanded="false">
+                                <h4 class="au-name"><?php echo esc_html($name); ?></h4>
+                                <?php $live = (string) get_post_meta($aid, COPELLA_AUTHOR_META_IS_LIVE, true) === '1'; ?>
+                                <span class="au-live <?php echo $live ? 'is-on' : 'is-off'; ?>" aria-label="<?php echo esc_attr($live ? __('В эфире', 'copella-topics') : __('Нет эфира', 'copella-topics')); ?>"></span>
+                                <span class="au-live-label"><?php echo $live ? esc_html__('В эфире', 'copella-topics') : esc_html__('Нет эфира', 'copella-topics'); ?></span>
+                                <button class="au-arrow" type="button" aria-label="<?php echo esc_attr__('Развернуть', 'copella-topics'); ?>"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                            </div>
+                            <div class="au-cover">
+                                <?php if ($cover): ?><img src="<?php echo esc_url($cover); ?>" alt="" loading="lazy"/><?php endif; ?>
+                                <?php if (!empty($link)): ?><a class="au-watch" href="<?php echo esc_url($link); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html__('Смотреть', 'copella-topics'); ?></a><?php endif; ?>
+                            </div>
+                            <div class="au-body">
+                                <?php if (!empty($desc)): ?><p class="au-desc"><?php echo esc_html($desc); ?></p><?php endif; ?>
+                                <?php if ($programId > 0): ?>
+                                    <?php $summ = copella_topics_fetch_tvschedule_summary($programId, 3); echo '<div class="au-stream-program">' . copella_topics_render_schedule_compact($summ) . '</div>'; ?>
+                                <?php endif; ?>
+                                <?php echo copella_topics_render_author_social_networks($aid); ?>
+                            </div>
+                        </article>
+                        <?php endwhile; wp_reset_postdata(); ?>
+                    </div>
+                </div>
+                <?php
+                $panelIndex = 0;
+                $q->rewind_posts();
+                while ($q->have_posts()): $q->the_post();
+                    $aid = get_the_ID();
+                    $name = get_the_title();
+                    $cover = get_the_post_thumbnail_url($aid, 'medium_large');
+                    $streamUrl = (string) get_post_meta($aid, COPELLA_AUTHOR_META_STREAM_URL, true);
+                    $isLive = (string) get_post_meta($aid, COPELLA_AUTHOR_META_IS_LIVE, true) === '1';
+                    $desc = copella_topics_get_author_desc($aid);
+                    $link = $streamUrl ?: get_permalink($aid);
+                    $programId = (int) get_post_meta($aid, COPELLA_AUTHOR_META_PROGRAM_ID, true);
+                ?>
+                    <div class="au-panel" role="tabpanel" id="<?php echo esc_attr($uid . '_panel_' . $panelIndex); ?>" aria-labelledby="<?php echo esc_attr($uid . '_tab_' . $panelIndex); ?>" data-au-index="<?php echo (int) $panelIndex; ?>">
+                        <div class="au-grid au-grid--individual-tab">
+                            <article class="au-card is-stream au-card--full-width au-card--no-cover">
+                                <div class="au-header" role="button" tabindex="0" aria-expanded="true">
+                                    <h4 class="au-name">
+                                        <?php if ($cover): ?>
+                                            <span class="au-author-icon">
+                                                <img src="<?php echo esc_url($cover); ?>" alt="" loading="lazy"/>
+                                            </span>
+                                        <?php else: ?>
+                                            <span class="au-author-icon"><?php echo esc_html(mb_substr($name, 0, 1)); ?></span>
+                                        <?php endif; ?>
+                                        <?php echo esc_html($name); ?>
+                                    </h4>
+                                    <?php $live = (string) get_post_meta($aid, COPELLA_AUTHOR_META_IS_LIVE, true) === '1'; ?>
+                                    <span class="au-live <?php echo $live ? 'is-on' : 'is-off'; ?>" aria-label="<?php echo esc_attr($live ? __('В эфире', 'copella-topics') : __('Нет эфира', 'copella-topics')); ?>"></span>
+                                    <span class="au-live-label"><?php echo $live ? esc_html__('В эфире', 'copella-topics') : esc_html__('Нет эфира', 'copella-topics'); ?></span>
+                                </div>
+                                <div class="au-body">
+                                    <?php if (!empty($desc)): ?><p class="au-desc"><?php echo esc_html($desc); ?></p><?php endif; ?>
+                                    <?php if ($programId > 0): ?>
+                                        <?php $summ = copella_topics_fetch_tvschedule_summary($programId, 3); echo '<div class="au-stream-program">' . copella_topics_render_schedule_compact($summ) . '</div>'; ?>
+                                    <?php endif; ?>
+                                    <?php echo copella_topics_render_author_social_networks($aid); ?>
+                                    <?php if (!empty($link)): ?><p><a class="au-watch-link" href="<?php echo esc_url($link); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html__('Смотреть стрим', 'copella-topics'); ?></a></p><?php endif; ?>
+                                </div>
+                            </article>
+                        </div>
+                    </div>
+                <?php
+                    $panelIndex++;
+                endwhile;
+                wp_reset_postdata();
+                ?>
+            </div>
+        <?php else: ?>
+            <div class="au-grid">
+                <?php if ($q->have_posts()): while ($q->have_posts()): $q->the_post();
+                    $aid = get_the_ID();
+                    $name = get_the_title();
+                    $cover = get_the_post_thumbnail_url($aid, 'medium_large');
+                    $streamUrl = (string) get_post_meta($aid, COPELLA_AUTHOR_META_STREAM_URL, true);
+                    $isLive = (string) get_post_meta($aid, COPELLA_AUTHOR_META_IS_LIVE, true) === '1';
+                    $desc = copella_topics_get_author_desc($aid);
+                    $link = $streamUrl ?: get_permalink($aid);
+                    $programId = (int) get_post_meta($aid, COPELLA_AUTHOR_META_PROGRAM_ID, true);
+                ?>
+                <article class="au-card is-stream is-collapsed">
+                    <div class="au-header" role="button" tabindex="0" aria-expanded="false">
+                        <h4 class="au-name"><?php echo esc_html($name); ?></h4>
+                        <?php $live = (string) get_post_meta($aid, COPELLA_AUTHOR_META_IS_LIVE, true) === '1'; ?>
+                        <span class="au-live <?php echo $live ? 'is-on' : 'is-off'; ?>" aria-label="<?php echo esc_attr($live ? __('В эфире', 'copella-topics') : __('Нет эфира', 'copella-topics')); ?>"></span>
+                        <span class="au-live-label"><?php echo $live ? esc_html__('В эфире', 'copella-topics') : esc_html__('Нет эфира', 'copella-topics'); ?></span>
+                        <button class="au-arrow" type="button" aria-label="<?php echo esc_attr__('Развернуть', 'copella-topics'); ?>"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                    </div>
+                    <div class="au-cover">
+                        <?php if ($cover): ?><img src="<?php echo esc_url($cover); ?>" alt="" loading="lazy"/><?php endif; ?>
+                        <?php if (!empty($link)): ?><a class="au-watch" href="<?php echo esc_url($link); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html__('Смотреть', 'copella-topics'); ?></a><?php endif; ?>
+                    </div>
+                    <div class="au-body">
+                        <?php if (!empty($desc)): ?><p class="au-desc"><?php echo esc_html($desc); ?></p><?php endif; ?>
+                        <?php if ($programId > 0): ?>
+                            <?php $summ = copella_topics_fetch_tvschedule_summary($programId, 3); echo '<div class="au-stream-program">' . copella_topics_render_schedule_compact($summ) . '</div>'; ?>
+                        <?php endif; ?>
+                        <?php echo copella_topics_render_author_social_networks($aid); ?>
+                    </div>
+                </article>
+                <?php endwhile; wp_reset_postdata(); else: ?>
+                    <div class="au-empty"><?php echo esc_html__('Авторы не найдены.', 'copella-topics'); ?></div>
+                <?php endif; ?>
+            </div>
+        <?php endif; ?>
+    </section>
+    
+    <script>
+    // Initialize this specific author container when DOM is ready
+    (function() {
+        if (typeof window.CopellaAuthors !== 'undefined') {
+            var container = document.getElementById('<?php echo esc_js($uid); ?>');
+            if (container) {
+                window.CopellaAuthors.init(container);
+            }
+        }
+    })();
+    </script>
+    <?php
+    return ob_get_clean();
+}
+
+/**
+ * Shortcode: [playlist_authors] - Render authors with playlists
+ */
+function copella_topics_render_authors(array $atts = []): string
+{
+    $a = shortcode_atts(array(
+        'title' => __('Авторы', 'copella-topics'),
+        'posts_per_page' => '50',
+        'columns' => '3',
+        'gap' => '24',
+        'cover_ratio' => '16/9',
+        'layout' => 'tabs',
+    ), $atts, 'playlist_authors');
+
+    $title = trim((string)$a['title']);
+    $perPage = max(1, (int)$a['posts_per_page']);
+    $columns = max(1, min(4, (int)$a['columns']));
+    $gap = max(8, (int)$a['gap']);
+    $coverRatio = preg_replace('~[^0-9/\.]+~', '', (string) $a['cover_ratio']);
+    $layout = strtolower(trim((string)$a['layout'])) === 'grid' ? 'grid' : 'tabs';
+
+    $q = new WP_Query(array(
+        'post_type' => 'topic_author',
+        'post_status' => 'publish',
+        'posts_per_page' => $perPage,
+        'orderby' => 'menu_order title',
+        'order' => 'ASC',
+        'no_found_rows' => true,
+    ));
+
+    $uid = 'pl_authors_' . wp_generate_password(8, false, false);
+    ob_start();
+    ?>
+    <section id="<?php echo esc_attr($uid); ?>" class="copella-authors<?php echo $layout === 'tabs' ? ' is-tabs' : ''; ?>" style="<?php echo esc_attr(sprintf('--au-cols:%d;--au-gap:%dpx;--au-cover-ratio:%s;', $columns, $gap, $coverRatio ?: '16/9')); ?>">
+        <?php if ($title !== ''): ?><h3 class="au-title"><?php echo esc_html($title); ?></h3><?php endif; ?>
+        
+        <?php if ($layout === 'tabs' && $q->have_posts()): ?>
+            <div class="au-tabsbar" aria-label="<?php echo esc_attr__('Авторы', 'copella-topics'); ?>">
+                <button class="au-tabs-nav au-prev" type="button" aria-label="<?php echo esc_attr__('Назад', 'copella-topics'); ?>" title="<?php echo esc_attr__('Назад', 'copella-topics'); ?>">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M15 5L8 12L15 19" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                </button>
+                <div class="au-tabs-viewport">
+                    <div class="au-tabs" role="tablist">
+                        <button type="button" class="au-tab is-active" role="tab" aria-selected="true" aria-controls="<?php echo esc_attr($uid . '_panel_all'); ?>" id="<?php echo esc_attr($uid . '_tab_all'); ?>" data-au-index="all">
+                            <?php echo esc_html__('Все', 'copella-topics'); ?>
+                        </button>
+                        <?php
+                        $tabIndex = 0;
+                        while ($q->have_posts()): $q->the_post();
+                            $authorId = get_the_ID();
+                            $authorName = get_the_title();
+                        ?>
+                            <button type="button" class="au-tab" role="tab" aria-selected="false" aria-controls="<?php echo esc_attr($uid . '_panel_' . $tabIndex); ?>" id="<?php echo esc_attr($uid . '_tab_' . $tabIndex); ?>" data-au-index="<?php echo (int) $tabIndex; ?>">
+                                <?php echo esc_html($authorName); ?>
+                            </button>
+                        <?php
+                            $tabIndex++;
+                        endwhile;
+                        wp_reset_postdata();
+                        ?>
+                    </div>
+                </div>
+                <button class="au-tabs-nav au-next" type="button" aria-label="<?php echo esc_attr__('Вперед', 'copella-topics'); ?>" title="<?php echo esc_attr__('Вперед', 'copella-topics'); ?>">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M9 5L16 12L9 19" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                </button>
+            </div>
+            
+            <div class="au-panels">
+                <!-- Панель "Все" -->
+                <div class="au-panel is-active" role="tabpanel" id="<?php echo esc_attr($uid . '_panel_all'); ?>" aria-labelledby="<?php echo esc_attr($uid . '_tab_all'); ?>" data-au-index="all">
+                    <div class="au-grid">
+                        <?php
+                        $q->rewind_posts();
+                        while ($q->have_posts()): $q->the_post();
+                            $aid = get_the_ID();
+                            $name = get_the_title();
+                            $cover = get_the_post_thumbnail_url($aid, 'medium_large');
+                            $desc = copella_topics_get_author_desc($aid);
+                            $pl_ids = copella_topics_get_author_playlist_ids($aid);
+                        ?>
+                            <article class="au-card au-card--full-width">
+                                <div class="au-header">
+                                    <h4 class="au-name"><?php echo esc_html($name); ?></h4>
+                                </div>
+                                <div class="au-cover" aria-hidden="true">
+                                    <?php if ($cover): ?><img src="<?php echo esc_url($cover); ?>" alt="" loading="lazy"/><?php endif; ?>
+                                </div>
+                                <div class="au-body">
+                                    <?php if (!empty($desc)): ?><p class="au-desc"><?php echo esc_html($desc); ?></p><?php endif; ?>
+                                    <?php echo copella_topics_render_author_social_networks($aid); ?>
+                                    <?php echo copella_topics_render_author_playlists($pl_ids, true, true); ?>
+                                </div>
+                            </article>
+                        <?php
+                        endwhile;
+                        wp_reset_postdata();
+                        ?>
+                    </div>
+                </div>
+                
+                <!-- Панели отдельных авторов -->
+                <?php
+                $panelIndex = 0;
+                $q->rewind_posts();
+                while ($q->have_posts()): $q->the_post();
+                    $aid = get_the_ID();
+                    $name = get_the_title();
+                    $cover = get_the_post_thumbnail_url($aid, 'medium_large');
+                    $desc = copella_topics_get_author_desc($aid);
+                    $pl_ids = copella_topics_get_author_playlist_ids($aid);
+                ?>
+                    <div class="au-panel" role="tabpanel" id="<?php echo esc_attr($uid . '_panel_' . $panelIndex); ?>" aria-labelledby="<?php echo esc_attr($uid . '_tab_' . $panelIndex); ?>" data-au-index="<?php echo (int) $panelIndex; ?>">
+                        <div class="au-grid au-grid--individual-tab">
+                            <article class="au-card au-card--full-width au-card--no-cover">
+                                <div class="au-header">
+                                    <h4 class="au-name">
+                                        <?php if ($cover): ?>
+                                            <span class="au-author-icon">
+                                                <img src="<?php echo esc_url($cover); ?>" alt="" loading="lazy"/>
+                                            </span>
+                                        <?php else: ?>
+                                            <span class="au-author-icon"><?php echo esc_html(mb_substr($name, 0, 1)); ?></span>
+                                        <?php endif; ?>
+                                        <?php echo esc_html($name); ?>
+                                    </h4>
+                                </div>
+                                <div class="au-body">
+                                    <?php if (!empty($desc)): ?><p class="au-desc"><?php echo esc_html($desc); ?></p><?php endif; ?>
+                                    <?php echo copella_topics_render_author_social_networks($aid); ?>
+                                    <?php echo copella_topics_render_author_playlists($pl_ids, true, true); ?>
+                                </div>
+                            </article>
+                        </div>
+                    </div>
+                <?php
+                    $panelIndex++;
+                endwhile;
+                wp_reset_postdata();
+                ?>
+            </div>
+        <?php else: ?>
+            <div class="au-grid">
+                <?php if ($q->have_posts()): ?>
+                    <?php while ($q->have_posts()): ?>
+                        <?php $q->the_post(); ?>
+                        <?php
+                    $aid = get_the_ID();
+                    $name = get_the_title();
+                    $cover = get_the_post_thumbnail_url($aid, 'medium_large');
+                    $desc = copella_topics_get_author_desc($aid);
+                    $pl_ids = copella_topics_get_author_playlist_ids($aid);
+                ?>
+                <article class="au-card is-collapsed">
+                    <div class="au-header" role="button" tabindex="0" aria-expanded="false">
+                        <?php $authorPageId = (int) get_post_meta($aid, COPELLA_AUTHOR_META_PAGE_ID, true); $authorPageUrl = $authorPageId ? get_permalink($authorPageId) : ''; ?>
+                        <?php if ($authorPageUrl): ?>
+                        <h4 class="au-name"><a href="<?php echo esc_url($authorPageUrl); ?>"><?php echo esc_html($name); ?></a></h4>
+                        <?php else: ?>
+                        <h4 class="au-name"><?php echo esc_html($name); ?></h4>
+                        <?php endif; ?>
+                        <button class="au-arrow" type="button" aria-label="<?php echo esc_attr__('Развернуть', 'copella-topics'); ?>"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                    </div>
+                    <div class="au-cover" aria-hidden="true">
+                        <?php if ($cover): ?><img src="<?php echo esc_url($cover); ?>" alt="" loading="lazy"/><?php endif; ?>
+                    </div>
+                    <div class="au-body">
+                        <?php if (!empty($desc)): ?><p class="au-desc"><?php echo esc_html($desc); ?></p><?php endif; ?>
+                        <?php echo copella_topics_render_author_social_networks($aid); ?>
+                        <?php echo copella_topics_render_author_playlists($pl_ids); ?>
+                    </div>
+                </article>
+                    <?php endwhile; ?>
+                    <?php wp_reset_postdata(); ?>
+                <?php else: ?>
+                    <div class="au-empty"><?php echo esc_html__('Авторы не найдены.', 'copella-topics'); ?></div>
+                <?php endif; ?>
+            </div>
+        <?php endif; ?>
+    </section>
+    
+    <script>
+    // Initialize this specific author container when DOM is ready
+    (function() {
+        if (typeof window.CopellaAuthors !== 'undefined') {
+            var container = document.getElementById('<?php echo esc_js($uid); ?>');
+            if (container) {
+                window.CopellaAuthors.init(container);
+            }
+        }
+    })();
+    </script>
+    <?php
+    return ob_get_clean();
+}
+
+/**
+ * Shortcode: [playlist_author] - Render single author
+ */
+function copella_topics_render_author(array $atts = []): string
+{
+    $a = shortcode_atts(array(
+        'author_id' => '0',
+        'id' => '0',
+        'cover_ratio' => '16/9',
+    ), $atts, 'playlist_author');
+
+    $aid = (int) ($a['author_id'] ?: $a['id']);
+    if ($aid <= 0 && get_post_type() === 'topic_author') {
+        $aid = get_the_ID();
+    }
+    if ($aid <= 0) {
+        return '';
+    }
+
+    $name = get_the_title($aid);
+    $cover = get_the_post_thumbnail_url($aid, 'large');
+    $desc = copella_topics_get_author_desc($aid);
+    $pl_ids = copella_topics_get_author_playlist_ids($aid);
+    $coverRatio = preg_replace('~[^0-9/\.]+~', '', (string) $a['cover_ratio']);
+
+    $uid = 'pl_author_' . wp_generate_password(8, false, false);
+    ob_start();
+    ?>
+    <section id="<?php echo esc_attr($uid); ?>" class="copella-authors" style="<?php echo esc_attr(sprintf('--au-cols:%d;--au-cover-ratio:%s;', 1, $coverRatio)); ?>">
+        <div class="au-grid">
+            <article class="au-card is-collapsed">
+                <div class="au-header" role="button" tabindex="0" aria-expanded="false">
+                    <h4 class="au-name"><?php echo esc_html($name); ?></h4>
+                    <button class="au-arrow" type="button" aria-label="<?php echo esc_attr__('Свернуть', 'copella-topics'); ?>"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                </div>
+                <div class="au-cover" aria-hidden="true">
+                    <?php if ($cover): ?><img src="<?php echo esc_url($cover); ?>" alt="" loading="lazy"/><?php endif; ?>
+                </div>
+                <div class="au-body">
+                    <?php if (!empty($desc)): ?><p class="au-desc"><?php echo esc_html($desc); ?></p><?php endif; ?>
+                    <?php echo copella_topics_render_author_social_networks($aid); ?>
+                    <?php echo copella_topics_render_author_playlists($pl_ids); ?>
+                </div>
+            </article>
+        </div>
+    </section>
+    
+    <script>
+    // Initialize this specific author container when DOM is ready
+    (function() {
+        if (typeof window.CopellaAuthors !== 'undefined') {
+            var container = document.getElementById('<?php echo esc_js($uid); ?>');
+            if (container) {
+                window.CopellaAuthors.init(container);
+            }
+        }
+    })();
+    </script>
+    <?php
+    return ob_get_clean();
+}

--- a/plugin2/topics-playlists-plugin/includes/shortcodes-playlists.php
+++ b/plugin2/topics-playlists-plugin/includes/shortcodes-playlists.php
@@ -1,0 +1,397 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Shortcode: [topic_playlist] - Render topic playlist
+ */
+function copella_topics_render_playlist(array $atts = []): string
+{
+    $a = shortcode_atts(array(
+        'playlist_id' => '0',
+        'id' => '0',
+        'title' => '',
+        'aspect_ratio' => '1/1',
+        'card_radius' => '18',
+        'container_radius' => '28',
+        'container_bg' => '#171717',
+        'layout' => 'list',
+        'grid_min' => '220',
+        'cover' => 'true',
+        'cover_align' => 'right',
+        'cover_height' => '220',
+        'cover_radius' => '',
+        'collapsed' => 'true',
+        'default_tag' => '',
+    ), $atts, 'topic_playlist');
+
+    $playlist_id = (int) ($a['playlist_id'] ?: $a['id']);
+    if ($playlist_id <= 0 && get_post_type() === 'topic_playlist') {
+        $playlist_id = get_the_ID();
+    }
+    if ($playlist_id <= 0) {
+        return '';
+    }
+
+    $title = trim((string) $a['title']);
+    if ($title === '') {
+        $title = get_the_title($playlist_id);
+    }
+    $aspectRatio = preg_replace('~[^0-9/\.]+~', '', (string) $a['aspect_ratio']);
+    $cardRadius = (int) $a['card_radius'];
+    $containerRadius = (int) $a['container_radius'];
+    $containerBg = sanitize_hex_color((string) $a['container_bg']) ?: '#171717';
+    $layout = strtolower(trim((string) $a['layout'])) === 'grid' ? 'grid' : 'list';
+    $gridMin = max(160, (int) $a['grid_min']);
+
+    $coverEnabled = filter_var($a['cover'], FILTER_VALIDATE_BOOLEAN);
+    $coverAlign = in_array(strtolower((string)$a['cover_align']), array('left','right'), true) ? strtolower((string)$a['cover_align']) : 'right';
+    $coverHeight = max(180, (int) $a['cover_height']);
+    $coverRadius = (string)$a['cover_radius'] !== '' ? (int)$a['cover_radius'] : $containerRadius;
+    $isCollapsed = filter_var($a['collapsed'], FILTER_VALIDATE_BOOLEAN);
+    $defaultTag = trim((string) $a['default_tag']);
+
+    $groupsMap = array();
+    $videos_raw = (string) get_post_meta($playlist_id, COPELLA_PLAYLIST_META_ITEMS, true);
+    $rawLines = preg_split("/\r\n|\r|\n/", $videos_raw);
+    $currentGroup = '_default';
+    if (is_array($rawLines)) {
+        foreach ($rawLines as $rawLine) {
+            $line = trim((string) $rawLine);
+            if ($line === '') { continue; }
+            if (preg_match('~^#+\s*(.+)$~u', $line, $m)) {
+                $currentGroup = trim((string) $m[1]);
+                if ($currentGroup === '') { $currentGroup = '_default'; }
+                if (!array_key_exists($currentGroup, $groupsMap)) { $groupsMap[$currentGroup] = array(); }
+                continue;
+            }
+
+            $meta = array('tag' => '', 'color' => '');
+            $parts = array_map('trim', explode('|', $line));
+            $idOrUrl = array_shift($parts);
+            foreach ($parts as $p) {
+                if (stripos($p, 'tag=') === 0) { $meta['tag'] = trim(substr($p, 4)); }
+                if (stripos($p, 'color=') === 0) { $c = trim(substr($p, 6)); $meta['color'] = sanitize_hex_color($c) ?: $c; }
+            }
+
+            $item = array('href' => '', 'title' => '', 'thumb' => '', 'date' => '', 'tag' => $meta['tag'], 'color' => $meta['color']);
+            if (ctype_digit($idOrUrl)) { $pid = (int) $idOrUrl; } else { $pid = url_to_postid($idOrUrl); }
+            if ($pid > 0) {
+                $item['href'] = get_permalink($pid);
+                $item['title'] = get_the_title($pid);
+                $item['thumb'] = get_the_post_thumbnail_url($pid, 'medium');
+                $item['date'] = get_the_date('', $pid);
+            } else {
+                $item['href'] = esc_url($idOrUrl);
+                $item['title'] = wp_parse_url($idOrUrl, PHP_URL_HOST) ?: $idOrUrl;
+                $item['thumb'] = '';
+            }
+
+            if ($item['tag'] === '' && $defaultTag !== '') {
+                $item['tag'] = $defaultTag;
+            }
+
+            if (!array_key_exists($currentGroup, $groupsMap)) { $groupsMap[$currentGroup] = array(); }
+            $groupsMap[$currentGroup][] = $item;
+        }
+    }
+
+    $groupNames = array_keys($groupsMap);
+    if (empty($groupNames)) {
+        $groupsMap['_default'] = array();
+        $groupNames = array('_default');
+    }
+    $hasNamedGroups = array_filter($groupNames, function ($g) { return $g !== '_default'; });
+    $useTabs = count($hasNamedGroups) > 1;
+
+    $uid = 'topic_pl_' . wp_generate_password(8, false, false);
+    ob_start();
+    ?>
+    <section id="<?php echo esc_attr($uid); ?>" class="copella-playlist<?php echo $coverEnabled ? ' has-cover' : ''; ?><?php echo $isCollapsed ? ' is-collapsed' : ''; ?>" data-pl-init="1" style="<?php echo esc_attr(sprintf('--pl-container-bg:%s;--pl-container-radius:%dpx;--pl-card-radius:%dpx;--pl-aspect:%s;--pl-grid-min:%dpx;--pl-cover-height:%dpx;--pl-cover-radius:%dpx;', $containerBg, $containerRadius, $cardRadius, $aspectRatio, $gridMin, $coverHeight, $coverRadius)); ?>">
+        <?php if ($coverEnabled):
+            $coverImage = get_the_post_thumbnail_url($playlist_id, 'large');
+            if (!$coverImage) {
+                $firstThumb = '';
+                foreach ($groupsMap as $items) {
+                    if (!empty($items) && !empty($items[0]['thumb'])) { $firstThumb = $items[0]['thumb']; break; }
+                }
+                $coverImage = $firstThumb ?: '';
+            }
+            $coverDesc = get_the_excerpt($playlist_id);
+        ?>
+        <div class="pl-cover pl-cover--<?php echo esc_attr($coverAlign); ?>"<?php echo $coverImage ? '' : ' data-empty-cover="1"'; ?>>
+            <?php if ($coverImage): ?>
+            <div class="pl-cover-media" aria-hidden="true">
+                <img src="<?php echo esc_url($coverImage); ?>" alt="" loading="lazy"/>
+            </div>
+            <?php endif; ?>
+            <div class="pl-cover-overlay" aria-hidden="true"></div>
+            <div class="pl-cover-content">
+                <h3 class="pl-cover-title"><?php echo esc_html($title); ?></h3>
+                <?php if (!empty($coverDesc)): ?>
+                    <p class="pl-cover-desc"><?php echo esc_html($coverDesc); ?></p>
+                <?php endif; ?>
+            </div>
+        </div>
+        <?php endif; ?>
+        <div class="pl-header" role="button" tabindex="0" aria-expanded="false" aria-controls="<?php echo esc_attr($uid); ?>_panels">
+            <h3 class="pl-title"><?php echo esc_html($title); ?></h3>
+            <span class="pl-arrow" aria-hidden="true">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </span>
+        </div>
+        <?php if ($useTabs): ?>
+            <div class="pl-tabsbar" aria-label="<?php echo esc_attr__('Категории плейлиста', 'copella-topics'); ?>">
+                <button class="pl-tabs-nav pl-prev" type="button" aria-label="<?php echo esc_attr__('Назад', 'copella-topics'); ?>" title="<?php echo esc_attr__('Назад', 'copella-topics'); ?>">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M15 5L8 12L15 19" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                </button>
+                <div class="pl-tabs-viewport">
+                    <div class="pl-tabs" role="tablist">
+                        <?php
+                        $tabIndex = 0;
+                        foreach ($groupNames as $gName):
+                            if ($gName === '_default') { continue; }
+                            $isActive = ($tabIndex === 0);
+                            ?>
+                            <button type="button" class="pl-tab <?php echo $isActive ? 'is-active' : ''; ?>" role="tab" aria-selected="<?php echo $isActive ? 'true' : 'false'; ?>" aria-controls="<?php echo esc_attr($uid . '_panel_' . $tabIndex); ?>" id="<?php echo esc_attr($uid . '_tab_' . $tabIndex); ?>" data-pl-index="<?php echo (int) $tabIndex; ?>">
+                                <?php echo esc_html($gName); ?>
+                            </button>
+                            <?php
+                            $tabIndex++;
+                        endforeach;
+                        ?>
+                    </div>
+                </div>
+                <button class="pl-tabs-nav pl-next" type="button" aria-label="<?php echo esc_attr__('Вперед', 'copella-topics'); ?>" title="<?php echo esc_attr__('Вперед', 'copella-topics'); ?>">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M9 5L16 12L9 19" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                </button>
+            </div>
+        <?php endif; ?>
+
+        <div class="pl-panels" id="<?php echo esc_attr($uid); ?>_panels">
+            <?php
+            $panelIndex = 0;
+            $renderGroups = !empty($hasNamedGroups) ? array_values(array_filter($groupNames, function($g){ return $g !== '_default'; })) : array('_default');
+            foreach ($renderGroups as $gName):
+                $groupItems = isset($groupsMap[$gName]) ? (array) $groupsMap[$gName] : array();
+                $isActive = ($panelIndex === 0);
+                ?>
+                <div class="pl-list <?php echo $layout === 'grid' ? 'is-grid ' : ''; ?><?php echo $isActive ? 'is-active' : ''; ?>" role="list" id="<?php echo esc_attr($uid . '_panel_' . $panelIndex); ?>" aria-labelledby="<?php echo esc_attr($uid . '_tab_' . $panelIndex); ?>" data-pl-index="<?php echo (int) $panelIndex; ?>">
+                    <?php if (empty($groupItems)): ?>
+                        <div class="pl-empty" role="status"><?php echo esc_html__('Тут ничего нет, но мы уже работаем над добавлением контента в этот плейлист.', 'copella-topics'); ?></div>
+                    <?php else: ?>
+                        <?php foreach ($groupItems as $it): ?>
+                        <a class="pl-item" role="listitem" href="<?php echo esc_url($it['href']); ?>" title="<?php echo esc_attr($it['title']); ?>">
+                            <span class="pl-thumb" aria-hidden="true">
+                                <?php if (!empty($it['thumb'])): ?>
+                                    <img src="<?php echo esc_url($it['thumb']); ?>" alt="" loading="lazy"/>
+                                <?php else: ?>
+                                    <span class="pl-fallback"></span>
+                                <?php endif; ?>
+                            </span>
+                            <span class="pl-item-body">
+                                <span class="pl-item-title"><?php echo esc_html($it['title']); ?></span>
+                                <?php if (!empty($it['tag'])): ?>
+                                    <span class="pl-item-badge"<?php echo !empty($it['color']) ? ' style="background:' . esc_attr($it['color']) . ';"' : ''; ?>><?php echo esc_html($it['tag']); ?></span>
+                                <?php endif; ?>
+                                <?php if (!empty($it['date'])): ?>
+                                    <span class="pl-item-meta"><?php echo esc_html($it['date']); ?></span>
+                                <?php endif; ?>
+                            </span>
+                        </a>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                </div>
+                <?php
+                $panelIndex++;
+            endforeach;
+            ?>
+        </div>
+        
+        <script>
+        (function(){
+            var root = document.getElementById('<?php echo esc_js($uid); ?>');
+            if(!root) return;
+            var header = root.querySelector('.pl-header');
+            var panels = root.querySelector('.pl-panels');
+            if(!header || !panels) return;
+            var tabs = Array.prototype.slice.call(root.querySelectorAll('.pl-tab'));
+            var animating = false;
+            var tabsTrack = root.querySelector('.pl-tabs');
+            var tabsPrev = root.querySelector('.pl-tabsbar .pl-prev');
+            var tabsNext = root.querySelector('.pl-tabsbar .pl-next');
+
+            function activeList(){
+                return panels.querySelector('.pl-list.is-active') || panels.querySelector('.pl-list');
+            }
+
+            function setPanelsHeightTo(el){
+                if(!el) return;
+                var height = el.scrollHeight;
+                if (height > 0) {
+                    panels.style.height = height + 'px';
+                }
+            }
+
+            function expand(){
+                if(animating) return; animating = true;
+                root.classList.remove('is-collapsed');
+                header.setAttribute('aria-expanded', 'true');
+                var current = activeList();
+                panels.style.overflow = 'hidden';
+                panels.style.height = '0px';
+                panels.style.opacity = '0';
+                panels.style.transition = 'height 280ms ease, opacity 280ms ease';
+                requestAnimationFrame(function(){
+                    if (current && current.scrollHeight > 0) {
+                        panels.style.height = current.scrollHeight + 'px';
+                    }
+                    panels.style.opacity = '1';
+                });
+                panels.addEventListener('transitionend', function tidy(ev){
+                    if (ev.propertyName !== 'height') return;
+                    panels.style.transition = '';
+                    panels.style.height = '';
+                    panels.style.overflow = '';
+                    panels.style.opacity = '';
+                    animating = false;
+                    panels.removeEventListener('transitionend', tidy);
+                });
+            }
+
+            function collapse(){
+                if(animating) return; animating = true;
+                header.setAttribute('aria-expanded', 'false');
+                var current = activeList();
+                panels.style.overflow = 'hidden';
+                if (current && current.scrollHeight > 0) {
+                    panels.style.height = current.scrollHeight + 'px';
+                }
+                panels.style.opacity = '1';
+                panels.style.transition = 'height 280ms ease, opacity 280ms ease';
+                requestAnimationFrame(function(){
+                    panels.style.height = '0px';
+                    panels.style.opacity = '0';
+                });
+                panels.addEventListener('transitionend', function tidy(ev){
+                    if (ev.propertyName !== 'height') return;
+                    root.classList.add('is-collapsed');
+                    panels.style.transition = '';
+                    panels.style.height = '0px';
+                    panels.style.opacity = '0';
+                    panels.style.overflow = 'hidden';
+                    animating = false;
+                    panels.removeEventListener('transitionend', tidy);
+                });
+            }
+
+            function toggle(ev){
+                var targetRoot = ev && ev.currentTarget ? ev.currentTarget.closest('.copella-playlist') : root;
+                if (targetRoot !== root) return;
+                if(root.classList.contains('is-collapsed')) expand(); else collapse();
+            }
+            header.addEventListener('click', toggle);
+            header.addEventListener('keydown', function(e){ if(e.key==='Enter' || e.key===' '){ e.preventDefault(); toggle(e); } });
+
+            function activateTab(index){
+                var next = panels.querySelector('.pl-list[data-pl-index="'+ index +'"]');
+                var current = activeList();
+                if(!next || next === current) return;
+
+                tabs.forEach(function(t){
+                    var isActive = (t.getAttribute('data-pl-index') === String(index));
+                    t.classList.toggle('is-active', isActive);
+                    t.setAttribute('aria-selected', isActive ? 'true' : 'false');
+                });
+
+                panels.style.overflow = 'hidden';
+                panels.style.transition = 'height 220ms ease';
+                panels.style.height = current ? current.scrollHeight + 'px' : '0px';
+                requestAnimationFrame(function(){
+                    if (current) current.classList.remove('is-active');
+                    next.classList.add('is-active');
+                    setPanelsHeightTo(next);
+                });
+                panels.addEventListener('transitionend', function tidy(ev){
+                    if (ev.propertyName !== 'height') return;
+                    panels.style.transition = '';
+                    panels.style.overflow = '';
+                    panels.style.height = '';
+                    panels.removeEventListener('transitionend', tidy);
+                });
+            }
+
+            root.addEventListener('click', function(e){
+                var el = e.target && e.target.closest ? e.target.closest('.pl-tab') : null;
+                if(!el || !root.contains(el)) return;
+                var idx = el.getAttribute('data-pl-index');
+                activateTab(idx);
+            });
+            root.addEventListener('keydown', function(e){
+                var el = e.target && e.target.closest ? e.target.closest('.pl-tab') : null;
+                if(!el || !root.contains(el)) return;
+                if(e.key==='Enter' || e.key===' '){ e.preventDefault(); activateTab(el.getAttribute('data-pl-index')); }
+            });
+
+            var initList = activeList();
+            if (root.classList.contains('is-collapsed')) {
+                header.setAttribute('aria-expanded', 'false');
+                panels.style.height = '0px';
+                panels.style.overflow = 'hidden';
+                panels.style.opacity = '0';
+            } else if (initList) {
+                if (initList.scrollHeight > 0) {
+                    panels.style.height = initList.scrollHeight + 'px';
+                }
+            }
+
+            window.addEventListener('resize', function(){
+                var curr = activeList();
+                if (curr && !root.classList.contains('is-collapsed')) {
+                    if (curr.scrollHeight > 0) {
+                        panels.style.height = curr.scrollHeight + 'px';
+                    }
+                }
+            });
+
+            if ('IntersectionObserver' in window) {
+                var io = new IntersectionObserver(function(entries){
+                    entries.forEach(function(entry){
+                        if (entry.isIntersecting) {
+                            var curr = activeList();
+                            if (curr && !root.classList.contains('is-collapsed')) {
+                                setPanelsHeightTo(curr);
+                            }
+                        }
+                    });
+                }, { threshold: 0.01 });
+                io.observe(root);
+            }
+
+            function getTabsScrollAmount(){ return Math.max(120, root.clientWidth/3 + 20); }
+            function updateTabsButtons(){
+                if(!tabsTrack || !tabsPrev || !tabsNext) return;
+                var max = tabsTrack.scrollWidth - tabsTrack.clientWidth - 1;
+                tabsPrev.disabled = tabsTrack.scrollLeft <= 1;
+                tabsNext.disabled = tabsTrack.scrollLeft >= max;
+                var tabsbar = root.querySelector('.pl-tabsbar');
+                if(tabsbar){ tabsbar.classList.toggle('has-scroll', max > 0); }
+            }
+            function scrollTabsBy(dir){ if(tabsTrack){ tabsTrack.scrollBy({ left: dir * getTabsScrollAmount(), behavior: 'smooth' }); } }
+            if(tabsPrev && tabsNext){
+                tabsPrev.addEventListener('click', function(){ scrollTabsBy(-1); });
+                tabsNext.addEventListener('click', function(){ scrollTabsBy(1); });
+            }
+            if(tabsTrack){
+                tabsTrack.addEventListener('scroll', updateTabsButtons, { passive:true });
+            }
+            window.addEventListener('resize', updateTabsButtons);
+            window.addEventListener('load', updateTabsButtons);
+            updateTabsButtons();
+        })();
+        </script>
+    </section>
+    <?php
+    return ob_get_clean();
+}

--- a/plugin2/topics-playlists-plugin/includes/shortcodes-topics.php
+++ b/plugin2/topics-playlists-plugin/includes/shortcodes-topics.php
@@ -1,0 +1,215 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Shortcode: [hot_topics] - Render hot topics carousel
+ */
+function copella_topics_render_hot_topics(array $atts = []): string
+{
+    $defaults = array(
+        'title'            => __('Горячие темы', 'copella-topics'),
+        'posts_per_page'   => '10',
+        'aspect_ratio'     => '1/1',
+        'card_radius'      => '28',
+        'gap'              => '28',
+        'container_radius' => '32',
+        'container_bg'     => '#171717',
+        'card_placeholder' => '#FF653A',
+        'paged'            => '1',
+        'stagger'          => 'false',
+        'stagger_offset'   => '56',
+    );
+
+    $a = shortcode_atts($defaults, $atts, 'hot_topics');
+
+    $title           = trim((string) $a['title']);
+    $postsPerPage    = max(1, (int) $a['posts_per_page']);
+    $aspectRatio     = preg_replace('~[^0-9/\.]+~', '', (string) $a['aspect_ratio']);
+    $cardRadius      = (int) $a['card_radius'];
+    $gap             = (int) $a['gap'];
+    $containerRadius = (int) $a['container_radius'];
+    $containerBg     = sanitize_hex_color((string) $a['container_bg']) ?: '#171717';
+    $cardPlaceholder = sanitize_hex_color((string) $a['card_placeholder']) ?: '#FF653A';
+    $stagger         = filter_var($a['stagger'], FILTER_VALIDATE_BOOLEAN);
+    $staggerOffset   = (int) $a['stagger_offset'];
+
+    $paged = isset($_GET['topics_page']) ? max(1, (int) $_GET['topics_page']) : max(1, (int) $a['paged']);
+
+    $query = new WP_Query(array(
+        'post_type'      => 'topic',
+        'post_status'    => ['publish', 'future'],  // Include scheduled posts
+        'posts_per_page' => $postsPerPage,
+        'paged'          => $paged,
+        'orderby'        => 'date',
+        'order'          => 'DESC',
+    ));
+
+    $total_topics = (int) $query->found_posts;
+    $max_pages    = max(1, (int) $query->max_num_pages);
+
+    $uid = 'hot_topics_' . wp_generate_password(8, false, false);
+
+    $styleVars = sprintf(
+        '--ht-gap:%dpx;--ht-card-radius:%dpx;--ht-container-radius:%dpx;--ht-aspect-ratio:%s;--ht-container-bg:%s;--ht-card-placeholder:%s;--ht-stagger:%dpx;',
+        $gap,
+        $cardRadius,
+        $containerRadius,
+        $aspectRatio,
+        $containerBg,
+        $cardPlaceholder,
+        $staggerOffset
+    );
+
+    ob_start();
+    ?>
+    <section id="<?php echo esc_attr($uid); ?>" class="copella-ht<?php echo $stagger ? ' is-staggered' : ''; ?>" style="<?php echo esc_attr($styleVars); ?>" aria-label="<?php echo esc_attr($title ?: __('Горячие темы', 'copella-topics')); ?>">
+        <div class="ht-header">
+            <div class="ht-titlebar">
+                <button class="ht-nav ht-prev" type="button" aria-label="<?php echo esc_attr__('Назад', 'copella-topics'); ?>" title="<?php echo esc_attr__('Назад', 'copella-topics'); ?>">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M15 5L8 12L15 19" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                </button>
+                <h3 class="ht-title"><?php echo esc_html($title ?: __('Горячие темы', 'copella-topics')); ?></h3>
+                <button class="ht-nav ht-next" type="button" aria-label="<?php echo esc_attr__('Вперед', 'copella-topics'); ?>" title="<?php echo esc_attr__('Вперед', 'copella-topics'); ?>">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M9 5L16 12L9 19" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                </button>
+            </div>
+            <div class="ht-count"><?php echo esc_html(sprintf(__('всего %d тем', 'copella-topics'), $total_topics)); ?></div>
+        </div>
+        <div class="ht-viewport">
+            <div class="ht-track" role="list">
+                <?php if ($query->have_posts()) : while ($query->have_posts()) : $query->the_post();
+                    $permalink = get_permalink();
+                    $customLink = (string) get_post_meta(get_the_ID(), COPELLA_TOPICS_META_LINK, true);
+                    $targetUrl = $customLink ? $customLink : $permalink;
+                    $postTitle = get_the_title();
+                    $thumbUrl  = get_the_post_thumbnail_url(get_the_ID(), 'medium_large');
+                    $postStatus = get_post_status();
+                    $isScheduled = ($postStatus === 'future');
+                    $publishTime = $isScheduled ? get_post_time('U', true) : null;
+                    $currentTime = time();
+                    $timeLeft = $isScheduled ? max(0, $publishTime - $currentTime) : 0;
+                ?>
+                <?php if ($isScheduled): ?>
+                    <div class="ht-card ht-scheduled" role="listitem" title="<?php echo esc_attr($postTitle); ?>" data-publish-time="<?php echo esc_attr($publishTime); ?>">
+                <?php else: ?>
+                    <a class="ht-card" role="listitem" href="<?php echo esc_url($targetUrl); ?>" title="<?php echo esc_attr($postTitle); ?>">
+                <?php endif; ?>
+                    <span class="ht-thumb" aria-hidden="true" style="<?php echo $thumbUrl ? '' : 'background:' . esc_attr($cardPlaceholder) . ';'; ?>">
+                        <?php if ($thumbUrl): ?>
+                            <img src="<?php echo esc_url($thumbUrl); ?>" alt="<?php echo esc_attr($postTitle); ?>" loading="lazy"/>
+                        <?php else: ?>
+                            <span class="ht-fallback"></span>
+                        <?php endif; ?>
+                        <?php if ($isScheduled): ?>
+                            <div class="ht-premiere-banner">
+                                <div class="ht-premiere-timer" data-target="<?php echo esc_attr($publishTime); ?>">
+                                    <span class="ht-premiere-label">ДО ПРЕМЬЕРЫ ОСТАЛОСЬ</span>
+                                    <span class="ht-premiere-time"><?php echo gmdate('H:i:s', $timeLeft); ?></span>
+                                </div>
+                            </div>
+                        <?php endif; ?>
+                    </span>
+                    <span class="ht-card-title"><?php echo esc_html($postTitle); ?></span>
+                <?php if ($isScheduled): ?>
+                    </div>
+                <?php else: ?>
+                    </a>
+                <?php endif; ?>
+                <?php endwhile; wp_reset_postdata(); else: ?>
+                    <div class="ht-empty" role="status"><?php _e('Тем пока нет.', 'copella-topics'); ?></div>
+                <?php endif; ?>
+            </div>
+        </div>
+
+        <?php if ($max_pages > 1): ?>
+        <nav class="ht-pagination" aria-label="<?php echo esc_attr__('Пагинация тем', 'copella-topics'); ?>">
+            <?php
+            $base_url = remove_query_arg('topics_page');
+            for ($i = 1; $i <= $max_pages; $i++) {
+                $url = esc_url(add_query_arg('topics_page', (string) $i, $base_url));
+                $class = $i === $paged ? 'class="is-active"' : '';
+                echo '<a ' . $class . ' href="' . $url . '">' . (int) $i . '</a>';
+            }
+            ?>
+        </nav>
+        <?php endif; ?>
+    </section>
+    <script>
+      (function(){
+        var root = document.getElementById('<?php echo esc_js($uid); ?>');
+        if(!root) return;
+        var track = root.querySelector('.ht-track');
+        var btnPrev = root.querySelector('.ht-prev');
+        var btnNext = root.querySelector('.ht-next');
+        if(!track || !btnPrev || !btnNext) return;
+
+        function getScrollAmount(){
+          return Math.max(120, root.clientWidth/3 + 20);
+        }
+        function updateButtons(){
+          var max = track.scrollWidth - track.clientWidth - 1;
+          btnPrev.disabled = track.scrollLeft <= 1;
+          btnNext.disabled = track.scrollLeft >= max;
+        }
+        function scrollByDir(dir){ track.scrollBy({ left: dir * getScrollAmount(), behavior: 'smooth'}); }
+
+        btnPrev.addEventListener('click', function(){ scrollByDir(-1); });
+        btnNext.addEventListener('click', function(){ scrollByDir(1); });
+        track.addEventListener('scroll', updateButtons, { passive:true });
+        window.addEventListener('resize', updateButtons);
+        updateButtons();
+        
+        // Premiere countdown functionality
+        function initPremiereCountdowns() {
+            var premiereTimers = root.querySelectorAll('.ht-premiere-timer[data-target]');
+            if (premiereTimers.length === 0) return;
+            
+            function updateCountdown(timer) {
+                var targetTime = parseInt(timer.getAttribute('data-target'), 10);
+                var currentTime = Math.floor(Date.now() / 1000);
+                var timeLeft = Math.max(0, targetTime - currentTime);
+                
+                if (timeLeft <= 0) {
+                    // Reload page when countdown reaches zero to show published post
+                    setTimeout(function() {
+                        window.location.reload();
+                    }, 500);
+                    return;
+                }
+                
+                var hours = Math.floor(timeLeft / 3600);
+                var minutes = Math.floor((timeLeft % 3600) / 60);
+                var seconds = timeLeft % 60;
+                
+                var timeDisplay = '';
+                if (hours > 0) {
+                    // Show H:MM:SS format when hours > 0
+                    timeDisplay = hours + ':' + (minutes < 10 ? '0' : '') + minutes + ':' + (seconds < 10 ? '0' : '') + seconds;
+                } else {
+                    // Show MM:SS format when less than 1 hour
+                    timeDisplay = (minutes < 10 ? '0' : '') + minutes + ':' + (seconds < 10 ? '0' : '') + seconds;
+                }
+                
+                var timeElement = timer.querySelector('.ht-premiere-time');
+                if (timeElement) {
+                    timeElement.textContent = timeDisplay;
+                }
+            }
+            
+            function updateAllCountdowns() {
+                premiereTimers.forEach(updateCountdown);
+            }
+            
+            // Update immediately and then every second
+            updateAllCountdowns();
+            setInterval(updateAllCountdowns, 1000);
+        }
+        
+        initPremiereCountdowns();
+      })();
+    </script>
+    <?php
+    return ob_get_clean();
+}

--- a/plugin2/topics-playlists-plugin/includes/shortcodes.php
+++ b/plugin2/topics-playlists-plugin/includes/shortcodes.php
@@ -1,0 +1,91 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+// Подключаем вспомогательные функции
+require_once __DIR__ . '/helpers.php';
+
+// Подключаем шорткоды для авторов
+require_once __DIR__ . '/shortcodes-authors.php';
+
+// Подключаем шорткоды для тем
+require_once __DIR__ . '/shortcodes-topics.php';
+
+// Подключаем шорткоды для плейлистов
+require_once __DIR__ . '/shortcodes-playlists.php';
+
+/**
+ * Bridge: [cpplayer_stream] - Render CP Player stream using author data from topics plugin
+ */
+function copella_topics_render_cpplayer_stream(array $atts = []): string
+{
+    $a = shortcode_atts([
+        'author_id' => '0',
+        'src' => '',
+        'title' => '',
+    ], $atts, 'cpplayer_stream');
+
+    $aid = (int) $a['author_id'];
+    $src = trim((string)$a['src']);
+    $title = (string)$a['title'];
+    if ($aid <= 0 || $src === '') {
+        return '';
+    }
+
+    $name = get_the_title($aid) ?: '';
+    $avatar = get_the_post_thumbnail_url($aid, 'thumbnail') ?: '';
+    $link = get_permalink($aid);
+
+    $cpplayer_atts = [
+        'src' => $src,
+        'type' => 'stream',
+        'title' => $title ?: $name,
+        'stream_author_name' => $name,
+        'stream_author_avatar' => $avatar,
+        'stream_author_link' => $link,
+    ];
+
+    $parts = [];
+    foreach ($cpplayer_atts as $k => $v) {
+        if ($v === '' || $v === null) continue;
+        $parts[] = $k . '="' . esc_attr($v) . '"';
+    }
+    $shortcode = '[cpplayer ' . implode(' ', $parts) . ']';
+    // Also ping live status endpoint optimistically (cpplayer will also report)
+    add_action('wp_footer', function() use ($aid) {
+        ?>
+        <script>
+        (function(){
+            try {
+                if (!window.copellaTopicsPinged) {
+                    window.copellaTopicsPinged = true;
+                    var fd = new FormData();
+                    fd.append('action','copella_topics_report_live');
+                    fd.append('author_id','<?php echo (int)$aid; ?>');
+                    fd.append('status','on');
+                    fetch('<?php echo esc_js(admin_url('admin-ajax.php')); ?>', { method:'POST', body: fd, credentials:'same-origin' });
+                }
+            } catch(_){}
+        })();
+        </script>
+        <?php
+    });
+    return do_shortcode($shortcode);
+}
+
+/**
+ * Регистрируем все шорткоды
+ */
+add_action('init', function (): void {
+    add_shortcode('hot_topics', 'copella_topics_render_hot_topics');
+    add_shortcode('topic_playlist', 'copella_topics_render_playlist');
+    add_shortcode('playlist_authors', 'copella_topics_render_authors');
+    add_shortcode('playlist_author', 'copella_topics_render_author');
+    add_shortcode('video_authors', 'copella_topics_render_video_authors');
+    add_shortcode('stream_authors', 'copella_topics_render_stream_authors');
+    // Bridge shortcode to render CP Player stream with author data from this plugin
+    add_shortcode('cpplayer_stream', 'copella_topics_render_cpplayer_stream');
+    // Attach author page to author card rendering (filter output by adding link if exists)
+});
+

--- a/plugin2/topics-playlists-plugin/topics-playlists-plugin.php
+++ b/plugin2/topics-playlists-plugin/topics-playlists-plugin.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Plugin Name: Copella Topics & Playlists
+ * Description: Создаёт тип записей «Темы/Плейлисты» и шорткоды для вывода блока «Горячие темы» с пагинацией.
+ * Version: 0.1.0
+ * Author: Copella
+ * Text Domain: copella-topics
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+// Constants
+define('COPELLA_TOPICS_PLUGIN_FILE', __FILE__);
+define('COPELLA_TOPICS_PLUGIN_DIR', plugin_dir_path(__FILE__));
+define('COPELLA_TOPICS_PLUGIN_URL', plugin_dir_url(__FILE__));
+
+// Activation/Deactivation: flush rewrite to register CPT permalinks
+register_activation_hook(__FILE__, function (): void {
+    require_once COPELLA_TOPICS_PLUGIN_DIR . 'includes/cpt.php';
+    copella_topics_register_cpt();
+    flush_rewrite_rules();
+});
+
+register_deactivation_hook(__FILE__, function (): void {
+    flush_rewrite_rules();
+});
+
+// Includes
+require_once COPELLA_TOPICS_PLUGIN_DIR . 'includes/cpt.php';
+require_once COPELLA_TOPICS_PLUGIN_DIR . 'includes/meta.php';
+require_once COPELLA_TOPICS_PLUGIN_DIR . 'includes/shortcodes.php';
+require_once COPELLA_TOPICS_PLUGIN_DIR . 'includes/author-page.php';
+require_once COPELLA_TOPICS_PLUGIN_DIR . 'includes/admin.php';
+require_once COPELLA_TOPICS_PLUGIN_DIR . 'includes/search.php';
+
+// Assets loader (frontend) – loaded only when shortcode is present
+function copella_topics_enqueue_assets(): void
+{
+    // Skip in admin, AJAX, REST API, and cron
+    if (is_admin() || wp_doing_ajax() || (defined('REST_REQUEST') && REST_REQUEST) || wp_doing_cron()) {
+        return;
+    }
+
+    // Detect shortcode usage in content
+    $should_enqueue = false;
+    $post = get_post();
+    
+    if ($post && isset($post->post_content)) {
+        $shortcodes = ['hot_topics', 'topic_playlist', 'playlist_authors', 'playlist_author', 'video_authors', 'stream_authors', 'cpplayer_stream', 'tp_search'];
+        foreach ($shortcodes as $shortcode) {
+            if (has_shortcode($post->post_content, $shortcode)) {
+                $should_enqueue = true;
+                break;
+            }
+        }
+    }
+    
+    // Check for author/topic pages
+    if (!$should_enqueue && (is_singular(['topic', 'topic_playlist', 'topic_author']) || is_post_type_archive(['topic', 'topic_playlist', 'topic_author']))) {
+        $should_enqueue = true;
+    }
+    
+    // Check for widgets containing shortcodes
+    if (!$should_enqueue && is_active_widget(false, false, 'text')) {
+        $sidebars = wp_get_sidebars_widgets();
+        foreach ($sidebars as $widgets) {
+            foreach ($widgets as $widget) {
+                if (strpos($widget, 'text') === 0) {
+                    $widget_content = get_option('widget_text');
+                    if ($widget_content) {
+                        foreach ($widget_content as $instance) {
+                            if (isset($instance['text'])) {
+                                $shortcodes = ['hot_topics', 'topic_playlist', 'playlist_authors'];
+                                foreach ($shortcodes as $shortcode) {
+                                    if (has_shortcode($instance['text'], $shortcode)) {
+                                        $should_enqueue = true;
+                                        break 3;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    if (!$should_enqueue) {
+        return;
+    }
+    // Basic styles for topics block
+    $css_file = COPELLA_TOPICS_PLUGIN_DIR . 'assets/css/topics.css';
+    wp_enqueue_style(
+        'copella-topics-styles',
+        COPELLA_TOPICS_PLUGIN_URL . 'assets/css/topics.css',
+        array(),
+        file_exists($css_file) ? (string) filemtime($css_file) : '0.1.0'
+    );
+
+    // Optional progressive enhancement script
+    $js_file = COPELLA_TOPICS_PLUGIN_DIR . 'assets/js/topics.js';
+    wp_enqueue_script(
+        'copella-topics-script',
+        COPELLA_TOPICS_PLUGIN_URL . 'assets/js/topics.js',
+        array(),
+        file_exists($js_file) ? (string) filemtime($js_file) : '0.1.0',
+        array(
+            'in_footer' => true,
+            'strategy'  => 'defer',
+        )
+    );
+    
+    // Playlist script
+    $playlist_js_file = COPELLA_TOPICS_PLUGIN_DIR . 'assets/js/playlist.js';
+    wp_enqueue_script(
+        'copella-playlist-script',
+        COPELLA_TOPICS_PLUGIN_URL . 'assets/js/playlist.js',
+        array(),
+        file_exists($playlist_js_file) ? (string) filemtime($playlist_js_file) : '0.1.0',
+        array(
+            'in_footer' => true,
+            'strategy'  => 'defer',
+        )
+    );
+    
+    // Authors interactive script
+    $authors_js_file = COPELLA_TOPICS_PLUGIN_DIR . 'assets/js/authors.js';
+    wp_enqueue_script(
+        'copella-authors-script',
+        COPELLA_TOPICS_PLUGIN_URL . 'assets/js/authors.js',
+        array(),
+        file_exists($authors_js_file) ? (string) filemtime($authors_js_file) : '0.1.0',
+        array(
+            'in_footer' => true,
+            'strategy'  => 'defer',
+        )
+    );
+}
+add_action('wp_enqueue_scripts', 'copella_topics_enqueue_assets');
+
+// Load text domain for translations
+add_action('plugins_loaded', function (): void {
+    load_plugin_textdomain('copella-topics', false, dirname(plugin_basename(__FILE__)) . '/languages');
+});
+


### PR DESCRIPTION
Unpack two WordPress plugins, 'Copella Top Creators' and 'Copella Topics Playlists', into their respective directories as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-02b22903-dbcc-4789-85b9-3e2762e6034d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-02b22903-dbcc-4789-85b9-3e2762e6034d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

